### PR TITLE
Select any taxon using Taxon#pretty_name

### DIFF
--- a/app/views/alchemy/essences/_essence_spree_taxon_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_spree_taxon_editor.html.erb
@@ -1,16 +1,15 @@
-<div class="content_editor">
-  <label><%= render_content_name(content) %></label>
+<div class="content_editor essence_spree_taxon essence_select">
+  <%= content_label(content) %>
   <%= select_tag(
     content.form_field_name,
-    option_groups_from_collection_for_select(
-      Spree::Taxon.all,
-      :children,
-      :name,
+    options_from_collection_for_select(
+      local_assigns.fetch(:options, {})[:taxons] || Spree::Taxon.all,
       :id,
-      :name,
+      :pretty_name,
       content.essence.taxon_id
     ),
-    :class => ['alchemy_selectbox very_long', html_options[:class]].join(' '),
-    :style => html_options[:style]
+    include_blank: t(".none"),
+    class: ["alchemy_selectbox", "essence_editor_select", html_options[:class]].join(' '),
+    style: html_options[:style]
   ) %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,5 @@
+en:
+  alchemy:
+    essences:
+      essence_spree_taxon_editor:
+        none: None


### PR DESCRIPTION
This allows the user to select any taxon from
the taxon hierarchy.

There's a few more changes in here to align this partial with the one found in `alchemy-spree`.
