### PR TITLE
Better integration

### DIFF
--- a/lib/alchemy/solidus/alchemy_in_solidus.rb
+++ b/lib/alchemy/solidus/alchemy_in_solidus.rb
@@ -1,3 +1,4 @@
 # Allow Alchemy content within Solidus views
 Spree::BaseController.send :include, Alchemy::ControllerActions
 Spree::UserSessionsController.send :include, Alchemy::ControllerActions if defined? Spree::UserSessionsController
+Spree::BaseController.send :include, Alchemy::ConfigurationMethods


### PR DESCRIPTION
For use Alchemy with multi-language we need the helpers contained in Alchemy::ConfigurationMethods like prefix_locale?
