### PR TITLE
Integration Alchemy in Solidus

### DIFF
--- a/lib/alchemy/solidus/engine.rb
+++ b/lib/alchemy/solidus/engine.rb
@@ -14,6 +14,7 @@ module Alchemy
 
       config.to_prepare do
         Alchemy.register_ability ::Spree::Ability
+        ::Spree::Ability.register_ability ::Alchemy::Permissions
         Spree::User.include Spree::AlchemyUserExtension if Alchemy.user_class_name == 'Spree::User'
         Alchemy::User.include Alchemy::SpreeUserExtension if Alchemy.user_class_name == 'Alchemy::User'
       end


### PR DESCRIPTION
If you integrate Alchemy in solidus, and you use alchemy helper for
rendering the page navigation, guest users not see the pages, because
the helpers receive the Spree::Ability, that hadn’t registered the
Alchemy::Permissions(Alias abilitys)