### PR TITLE
Remove dev files from gem build

### DIFF
--- a/alchemy-solidus.gemspec
+++ b/alchemy-solidus.gemspec
@@ -8,9 +8,8 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{The World's Most Flexible E-Commerce Platform meets The World's Most Flexible Content Management System!}
   gem.homepage      = "https://github.com/AlchemyCMS/alchemy-solidus"
   gem.license       = 'BSD New'
-  gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  gem.files         = `git ls-files`.split("\n")
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  gem.files         = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
+  gem.test_files    = Dir["spec/**/*"]
   gem.name          = "alchemy-solidus"
   gem.require_paths = ["lib"]
   gem.version       = Alchemy::Solidus::VERSION


### PR DESCRIPTION
This gem has no executables. We only need to include the files needed
for runtime into the final gem build.

Closes #22