### PR TITLE
Fix rescue of alchemy-devise load error

### DIFF
--- a/lib/generators/alchemy/solidus/install/install_generator.rb
+++ b/lib/generators/alchemy/solidus/install/install_generator.rb
@@ -5,7 +5,7 @@ require 'solidus_support'
 
 begin
   require 'generators/alchemy/devise/install/install_generator'
-rescue
+rescue LoadError
 end
 
 module Alchemy


### PR DESCRIPTION
TIL you need to explicitely rescue LoadError

Closes #24 