### PR TITLE
Fixes for Solidus 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
     - SOLIDUS_BRANCH=v2.2
     - SOLIDUS_BRANCH=v2.3
     - SOLIDUS_BRANCH=v2.4
+    - SOLIDUS_BRANCH=v2.5
+    - SOLIDUS_BRANCH=v2.6
     - SOLIDUS_BRANCH=master
 matrix:
   fast_finish: true

--- a/app/overrides/alchemy_solidus_tab.rb
+++ b/app/overrides/alchemy_solidus_tab.rb
@@ -1,6 +1,0 @@
-Deface::Override.new(
-  virtual_path: "spree/admin/shared/_menu",
-  name: "alchemy_cms_tab",
-  insert_bottom: '[data-hook="admin_tabs"]',
-  partial: "alchemy/admin/shared/alchemy_solidus_tab"
-)

--- a/app/views/alchemy/admin/shared/_alchemy_solidus_tab.html.erb
+++ b/app/views/alchemy/admin/shared/_alchemy_solidus_tab.html.erb
@@ -1,3 +1,0 @@
-<% if Spree.user_class && can?(:edit_content, Alchemy::Page) %>
-  <%= tab *[:cms], url: alchemy.admin_pages_path, icon: 'copy' %>
-<% end %>

--- a/app/views/spree/admin/shared/_alchemy_sub_menu.html.erb
+++ b/app/views/spree/admin/shared/_alchemy_sub_menu.html.erb
@@ -1,0 +1,23 @@
+<ul class="admin-subnav">
+  <% if can?(:index, :alchemy_admin_pages) %>
+    <%= tab :pages, label: :pages, url: alchemy.admin_pages_path %>
+  <% end %>
+  <% if can?(:index, :alchemy_admin_sites) %>
+    <%= tab :sites, label: :sites, url: alchemy.admin_sites_path %>
+  <% end %>
+  <% if can?(:index, :alchemy_admin_languages) %>
+    <%= tab :languages, label: :languages, url: alchemy.admin_languages_path %>
+  <% end %>
+  <% if can?(:index, :alchemy_admin_tags) %>
+    <%= tab :tags, label: :tags, url: alchemy.admin_tags_path %>
+  <% end %>
+  <% if defined?(Alchemy::User) && can?(:index, :alchemy_admin_users) %>
+    <%= tab :users, label: :users, url: alchemy.admin_users_path %>
+  <% end %>
+  <% if can?(:index, :alchemy_admin_pictures) %>
+    <%= tab :pictures, label: :pictures, url: alchemy.admin_pictures_path %>
+  <% end %>
+  <% if can?(:index, :alchemy_admin_attachments) %>
+    <%= tab :attachments, label: :attachments, url: alchemy.admin_attachments_path %>
+  <% end %>
+</ul>

--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -1,10 +1,49 @@
-Alchemy::Modules.register_module({
+alchemy_module = {
   engine_name: 'spree',
   name: 'solidus',
   navigation: {
     controller: 'spree/admin/orders',
     action: 'index',
-    name: 'Shop',
-    image: 'alchemy/solidus/alchemy_module_icon.png'
+    name: 'Store',
+    image: 'alchemy/solidus/alchemy_module_icon.png',
+    sub_navigation: [
+      {
+        controller: 'spree/admin/orders',
+        action: 'index',
+        name: 'Orders'
+      },
+      {
+        controller: 'spree/admin/products',
+        action: 'index',
+        name: 'Products'
+      },
+      {
+        controller: 'spree/admin/reports',
+        action: 'index',
+        name: 'Reports'
+      },
+      {
+        controller: 'spree/admin/promotions',
+        action: 'index',
+        name: 'Promotions'
+      },
+      {
+        controller: 'spree/admin/stock_items',
+        action: 'index',
+        name: 'Stock'
+      }
+    ]
   }
-})
+}
+
+if defined?(Spree::Auth::Engine)
+  alchemy_module[:navigation][:sub_navigation].push(
+    {
+      controller: 'spree/admin/users',
+      action: 'index',
+      name: 'Users'
+    }
+  )
+end
+
+Alchemy::Modules.register_module(alchemy_module)

--- a/config/locales/alchemy_solidus_en.yml
+++ b/config/locales/alchemy_solidus_en.yml
@@ -3,3 +3,10 @@ en:
     admin:
       tab:
         cms: CMS
+        pages: Pages
+        sites: Sites
+        languages: Languages
+        tags: Tags
+        users: Users
+        pictures: Pictures
+        attachments: Attachments

--- a/config/locales/alchemy_solidus_it.yml
+++ b/config/locales/alchemy_solidus_it.yml
@@ -3,3 +3,9 @@ it:
     admin:
       tab:
         cms: CMS
+        pages: "Pagine"
+        sites: "Siti"
+        languages: "Lingue"
+        tags: "Tags"
+        pictures: "Immagini"
+        attachments: "File"

--- a/lib/alchemy/solidus/engine.rb
+++ b/lib/alchemy/solidus/engine.rb
@@ -33,6 +33,16 @@ module Alchemy
           require 'alchemy/solidus/spree_install_generator_fix'
         end
       end
+
+      # Fix for +belongs_to :bill_address+ in {Spree::UserAddressBook}
+      # Solidus has this set to +false+ in {Spree::Base}, but {Alchemy::User} does not inherit from it.
+      initializer 'alchemy_solidus.belongs_bill_address_fix' do
+        if Alchemy.user_class_name == 'Alchemy::User'
+          ActiveSupport.on_load(:active_record) do
+            Alchemy::User.belongs_to_required_by_default = false
+          end
+        end
+      end
     end
   end
 end

--- a/lib/generators/alchemy/solidus/install/install_generator.rb
+++ b/lib/generators/alchemy/solidus/install/install_generator.rb
@@ -51,6 +51,22 @@ module Alchemy
         end
       end
 
+      def inject_admin_tab
+        inject_into_file 'config/initializers/spree.rb', {after: "Spree::Backend::Config.configure do |config|\n"} do
+          <<~ADMIN_TAB
+            \  # AlchemyCMS admin tabs
+            \  config.menu_items << config.class::MenuItem.new(
+            \    [:pages, :sites, :languages, :tags, :users, :pictures, :attachments],
+            \    'copy',
+            \    label: :cms,
+            \    condition: -> { can?(:index, :alchemy_admin_dashboard) },
+            \    partial: 'spree/admin/shared/alchemy_sub_menu',
+            \    url: '/admin/pages'
+            \  )
+          ADMIN_TAB
+        end
+      end
+
       def create_admin_user
         if Kernel.const_defined?('Alchemy::Devise') && !options[:skip_alchemy_user_generator] && Alchemy::User.count.zero?
           login = ENV.fetch('ALCHEMY_ADMIN_USER_LOGIN', 'admin')

--- a/lib/generators/alchemy/solidus/install/install_generator.rb
+++ b/lib/generators/alchemy/solidus/install/install_generator.rb
@@ -104,6 +104,26 @@ module Alchemy
           "\n  mount Alchemy::Engine, at: '/#{mountpoint.chomp('/')}'\n"
         end
       end
+
+      def set_root_route
+        routes_file_path = Rails.root.join('config', 'routes.rb')
+        if options[:auto_accept] || ask("\nDo you want Alchemy to handle the root route ('/')?", default: true)
+          if File.read(routes_file_path).match SPREE_MOUNT_REGEXP
+            sentinel = SPREE_MOUNT_REGEXP
+          else
+            sentinel = "Rails.application.routes.draw do\n"
+          end
+          inject_into_file routes_file_path, {after: sentinel} do
+            <<~ROOT_ROUTE
+              \n
+              \  # Let AlchemyCMS handle the root route
+              \  Spree::Core::Engine.routes.draw do
+              \    root to: '/alchemy/pages#index'
+              \  end
+            ROOT_ROUTE
+          end
+        end
+      end
     end
   end
 end

--- a/spec/features/alchemy/alchemy_admin_integrations_spec.rb
+++ b/spec/features/alchemy/alchemy_admin_integrations_spec.rb
@@ -6,18 +6,6 @@ end
 require 'spree/testing_support/factories/address_factory'
 
 RSpec.feature "Admin Integration", type: :feature do
-  let!(:admin) do
-    Alchemy::User.create!(
-      login: 'admin',
-      password: 'S3cre#t',
-      password_confirmation: 'S3cre#t',
-      email: 'email@example.com',
-      alchemy_roles: 'admin',
-      spree_roles: [Spree::Role.first_or_create!(name: 'admin')],
-      bill_address: FactoryBot.create(:address)
-    )
-  end
-
   it 'it is possible to login and visit Alchemy admin' do
     login!
     visit '/admin/dashboard'
@@ -38,8 +26,8 @@ RSpec.feature "Admin Integration", type: :feature do
     visit '/admin/login'
 
     expect(page).to have_field 'user_login'
-    fill_in 'user_login', with: admin.login
-    fill_in 'user_password', with: admin.password
+    fill_in 'user_login', with: 'admin'
+    fill_in 'user_password', with: 'test1234'
     click_button 'login'
   end
 end


### PR DESCRIPTION
Fixes some issues with Solidus 2.5

Mainly the bug with stores not having `solidus_frontend` installed get a routing error in `solidus_backend` because the `spree` routing proxy does not have the `root_url` method defined.

Then we use the backend configuration to add the menu tab into solidus admin, since Solidus does not require Deface per default and we do not want to either.

Also adds a admin user generator, because the default Alchemy admin signup does not work with Solidus, as it brings its own admin users controller that loads before alchemy-devises admin users controller, if mounted before Alchemy (what it usually does).
