### PR TITLE
Add data-turbolinks='false' to Solidus Subnav

### DIFF
--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -6,6 +6,7 @@ alchemy_module = {
     action: 'index',
     name: 'Store',
     image: 'alchemy/solidus/alchemy_module_icon.png',
+    data: { turbolinks: false },
     sub_navigation: [
       {
         controller: 'spree/admin/orders',


### PR DESCRIPTION
This adds a `data` key specifying that the Solidus submenu should not
be using Turbolinks. It's harmless with Alchemy versions that don't
support it, and beneficial for ones that do.