### PR TITLE
Alchemy master fixes

### DIFF
--- a/lib/alchemy/solidus/engine.rb
+++ b/lib/alchemy/solidus/engine.rb
@@ -26,6 +26,7 @@ module Alchemy
         if Alchemy.user_class_name == 'Alchemy::User'
           require 'alchemy/solidus/alchemy_user_extension'
           Alchemy::User.include Alchemy::Solidus::AlchemyUserExtension
+          require 'alchemy/solidus/spree_admin_unauthorized_redirect'
         end
 
         if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5')

--- a/lib/alchemy/solidus/spree_admin_unauthorized_redirect.rb
+++ b/lib/alchemy/solidus/spree_admin_unauthorized_redirect.rb
@@ -1,0 +1,9 @@
+Spree::Admin::BaseController.unauthorized_redirect = -> do
+  if try_spree_current_user
+    flash[:error] = I18n.t('spree.authorization_failure')
+    redirect_to spree.root_path
+  else
+    store_location
+    redirect_to alchemy.login_path
+  end
+end

--- a/lib/generators/alchemy/solidus/install/install_generator.rb
+++ b/lib/generators/alchemy/solidus/install/install_generator.rb
@@ -25,6 +25,8 @@ module Alchemy
       class_option :auto_accept, default: false, type: :boolean,
         desc: 'Set true if run from a automated script (ie. on a CI)'
 
+      source_root File.expand_path('templates', __dir__)
+
       def run_alchemy_installer
         unless options[:skip_alchemy_installer]
           arguments = options[:auto_accept] ? ['--skip-demo-files', '--force'] : []
@@ -49,6 +51,10 @@ module Alchemy
           end
           rake 'db:migrate'
         end
+      end
+
+      def copy_alchemy_initializer
+        template "alchemy.rb.tt", "config/initializers/alchemy.rb"
       end
 
       def inject_admin_tab

--- a/lib/generators/alchemy/solidus/install/install_generator.rb
+++ b/lib/generators/alchemy/solidus/install/install_generator.rb
@@ -45,7 +45,7 @@ module Alchemy
         if Kernel.const_defined?('Alchemy::Devise') && !options[:skip_spree_custom_user_generator]
           arguments = options[:auto_accept] ? ['Alchemy::User', '--force'] : ['Alchemy::User']
           Spree::CustomUserGenerator.start(arguments)
-          gsub_file 'lib/spree/authentication_helpers.rb', /main_app\./, 'alchemy.'
+          gsub_file 'lib/spree/authentication_helpers.rb', /main_app\./, 'Alchemy.'
           if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.0')
             gsub_file 'config/initializers/spree.rb', /Spree\.user_class.?=.?.+$/, 'Spree.user_class = "Alchemy::User"'
           end

--- a/lib/generators/alchemy/solidus/install/templates/alchemy.rb.tt
+++ b/lib/generators/alchemy/solidus/install/templates/alchemy.rb.tt
@@ -1,0 +1,42 @@
+Alchemy::Modules.register_module({
+  engine_name: 'spree',
+  name: 'solidus',
+  navigation: {
+    controller: 'spree/admin/orders',
+    action: 'index',
+    name: 'Store',
+    image: 'alchemy/solidus/alchemy_module_icon.png',
+    data: { turbolinks: false },
+    sub_navigation: [
+      {
+        controller: 'spree/admin/orders',
+        action: 'index',
+        name: 'Orders'
+      },
+      {
+        controller: 'spree/admin/products',
+        action: 'index',
+        name: 'Products'
+      },
+      {
+        controller: 'spree/admin/promotions',
+        action: 'index',
+        name: 'Promotions'
+      },
+      {
+        controller: 'spree/admin/stock_items',
+        action: 'index',
+        name: 'Stock'
+      <%- if defined?(Spree::Auth::Engine) -%>
+      },
+      {
+        controller: 'spree/admin/users',
+        action: 'index',
+        name: 'Users'
+      }
+      <%- else -%>
+      }
+      <%- end -%>
+    ]
+  }
+})

--- a/spec/features/alchemy/alchemy_admin_integrations_spec.rb
+++ b/spec/features/alchemy/alchemy_admin_integrations_spec.rb
@@ -7,6 +7,12 @@ end
 require 'spree/testing_support/factories/address_factory'
 
 RSpec.feature "Admin Integration", type: :feature do
+  it 'gets redirected to login if accessing admin' do
+    visit '/admin'
+
+    expect(page).to have_field 'user_login'
+  end
+
   it 'it is possible to login and visit Alchemy admin' do
     login!
     visit '/admin/dashboard'

--- a/spec/features/alchemy/alchemy_admin_integrations_spec.rb
+++ b/spec/features/alchemy/alchemy_admin_integrations_spec.rb
@@ -1,3 +1,4 @@
+require 'alchemy/version'
 require 'rails_helper'
 begin
   require 'factory_girl'
@@ -28,6 +29,6 @@ RSpec.feature "Admin Integration", type: :feature do
     expect(page).to have_field 'user_login'
     fill_in 'user_login', with: 'admin'
     fill_in 'user_password', with: 'test1234'
-    click_button 'login'
+    click_button Alchemy.version > '4.1.0' ? 'Login' : 'login'
   end
 end


### PR DESCRIPTION
Fixes for changes in latest Alchemy master (4.2.0) and adds a handler for Solidus' unauthorized redirect callback that is missing if we do not have `solidus_auth_devise` installed.
