### PR TITLE
Include all Solidus helpers when using Solidus layouts

### DIFF
--- a/lib/alchemy/solidus/use_solidus_layout.rb
+++ b/lib/alchemy/solidus/use_solidus_layout.rb
@@ -1,6 +1,11 @@
 # Include this to make Alchemy render within the Solidus layout
+
 Alchemy::BaseHelper.send :include, Spree::BaseHelper
+Alchemy::BaseHelper.send :include, Spree::CheckoutHelper
+Alchemy::BaseHelper.send :include, Spree::ProductsHelper
 Alchemy::BaseHelper.send :include, Spree::StoreHelper
+Alchemy::BaseHelper.send :include, Spree::TaxonsHelper
+
 Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Auth
 Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Common
 Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Order

--- a/lib/alchemy/solidus/use_solidus_layout.rb
+++ b/lib/alchemy/solidus/use_solidus_layout.rb
@@ -1,5 +1,11 @@
 # Include this to make Alchemy render within the Solidus layout
 Alchemy::BaseHelper.send :include, Spree::BaseHelper
 Alchemy::BaseHelper.send :include, Spree::StoreHelper
+Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Auth
 Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Common
+Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Order
+Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::PaymentParameters
+Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Pricing
+Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Search
 Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Store
+Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::StrongParameters


### PR DESCRIPTION
This PR addresses the issue where some Solidus helper methods were unavailable when called from Alchemy elements.