### PR TITLE
Match path fix for tabs in Solidus < 2.8

### DIFF
--- a/config/initializers/solidus.rb
+++ b/config/initializers/solidus.rb
@@ -1,0 +1,29 @@
+# In versions of Solidus prior to 2.8, we override this class to
+# add the match_path option to the initializer. (Version 2.8 has
+# this option already.) This option is used in the tabs partial
+# to configure the paths for which a given tab is active.
+#
+if Spree.solidus_gem_version < Gem::Version.new('2.8')
+  Spree::BackendConfiguration::MenuItem.class_eval do
+    attr_reader :match_path
+
+    def initialize(
+      sections,
+      icon,
+      condition: nil,
+      label: nil,
+      partial: nil,
+      url: nil,
+      match_path: nil
+    )
+
+      @condition = condition || -> { true }
+      @sections = sections
+      @icon = icon
+      @label = label || sections.first
+      @partial = partial
+      @url = url
+      @match_path = match_path
+    end
+  end
+end

--- a/lib/alchemy/solidus/engine.rb
+++ b/lib/alchemy/solidus/engine.rb
@@ -44,6 +44,15 @@ module Alchemy
           end
         end
       end
+      
+      # In versions of Solidus prior to 2.8, we override the tabs partial
+      # to pass a match_path value to each tab. (Version 2.8 is already
+      # passing this option.) This option is used to configure the paths
+      # for which a given tab is active.
+      #
+      if Spree.solidus_gem_version < Gem::Version.new('2.8')
+        paths['app/views'] << 'lib/views'
+      end
     end
   end
 end

--- a/lib/generators/alchemy/solidus/install/install_generator.rb
+++ b/lib/generators/alchemy/solidus/install/install_generator.rb
@@ -67,7 +67,8 @@ module Alchemy
             \    label: :cms,
             \    condition: -> { can?(:index, :alchemy_admin_dashboard) },
             \    partial: 'spree/admin/shared/alchemy_sub_menu',
-            \    url: '/admin/pages'
+            \    url: '/admin/pages',
+            \    match_path: '/pages'
             \  )
           ADMIN_TAB
         end

--- a/lib/views/spree/admin/shared/_tabs.html.erb
+++ b/lib/views/spree/admin/shared/_tabs.html.erb
@@ -1,0 +1,15 @@
+<% Spree::Backend::Config.menu_items.each do |menu_item| %>
+  <% if instance_exec(&menu_item.condition) %>
+    <%=
+      tab(
+          *menu_item.sections,
+          icon: menu_item.icon,
+          label: menu_item.label,
+          url: menu_item.url.is_a?(Symbol) ? spree.public_send(menu_item.url) : menu_item.url,
+          match_path: menu_item.match_path
+      ) do
+    %>
+      <%- render partial: menu_item.partial if menu_item.partial %>
+    <%- end %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
This fixes the "CMS" menu item in Solidus so that it doesn't appear open/selected when the "Users" page in the admin backend is active (see screenshot below).

This is accomplished by patching Solidus to enable the `match_path` option to be passed into the CMS `MenuItem` instance.

Because Solidus 2.8 already supports the `match_path` option, the `MenuItem` initializer patch and tab partial are conditionally loaded for versions of Solidus less than 2.8.

I've manually tested these changes against the CS app (Solidus 2.4) and it works as expected.

## Before

![Users](https://user-images.githubusercontent.com/3756/61378827-45aab980-a874-11e9-8ea6-4fe0a3dd8749.png)

## After

![Users](https://user-images.githubusercontent.com/3756/61378918-6e32b380-a874-11e9-8f1c-2a3ff44a7d4e.png)