### PR TITLE
Require at least Alchemy 4.1 and Solidus 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ sudo: false
 cache:
   bundler: true
 rvm:
-  - 2.4.2
+  - 2.5.5
 env:
   matrix:
     - SOLIDUS_BRANCH=v2.6
     - SOLIDUS_BRANCH=v2.7
     - SOLIDUS_BRANCH=v2.8
+    - SOLIDUS_BRANCH=v2.9
     - SOLIDUS_BRANCH=master
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
   - 2.5.5
 env:
   matrix:
+    - ALCHEMY_BRANCH=4.1-stable
+    - ALCHEMY_BRANCH=4.2-stable
+    - ALCHEMY_BRANCH=master
     - SOLIDUS_BRANCH=v2.6
     - SOLIDUS_BRANCH=v2.7
     - SOLIDUS_BRANCH=v2.8
@@ -15,5 +18,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: ALCHEMY_BRANCH=master
     - env: SOLIDUS_BRANCH=master
 script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ rvm:
   - 2.4.2
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.4
-    - SOLIDUS_BRANCH=v2.5
     - SOLIDUS_BRANCH=v2.6
     - SOLIDUS_BRANCH=v2.7
     - SOLIDUS_BRANCH=v2.8

--- a/Gemfile
+++ b/Gemfile
@@ -10,17 +10,4 @@ gemspec
 gem 'sqlite3', '~> 1.3.6' # Fix for sqlite v1.4 broken with latest Rails
 gem 'pry-rails'
 
-case solidus_branch
-when 'master'
-  gem 'alchemy_cms', github: 'AlchemyCMS/alchemy_cms'
-  gem 'alchemy-devise', github: 'AlchemyCMS/alchemy-devise'
-when 'v2.5'
-  gem 'alchemy_cms', '~> 4.0.4'
-  gem 'alchemy-devise', '~> 4.0.0'
-when 'v2.4'
-  gem 'factory_bot', '4.8.2'
-  gem 'alchemy_cms', '~> 4.0.4'
-  gem 'alchemy-devise', '~> 4.0.0'
-else
-  gem 'alchemy-devise', '~> 4.1.0'
-end
+gem 'alchemy-devise'

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,12 @@ solidus_branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem "solidus_core", github: "solidusio/solidus", branch: solidus_branch
 gem "solidus_backend", github: "solidusio/solidus", branch: solidus_branch
 
+alchemy_branch = ENV.fetch('ALCHEMY_BRANCH', 'master')
+gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: alchemy_branch
+gem 'alchemy-devise', github: "AlchemyCMS/alchemy-devise", branch: alchemy_branch
+
 # Specify your gem's dependencies in alchemy-solidus.gemspec
 gemspec
 
 gem 'sqlite3', '~> 1.3.6' # Fix for sqlite v1.4 broken with latest Rails
 gem 'pry-rails'
-
-gem 'alchemy-devise'

--- a/alchemy-solidus.gemspec
+++ b/alchemy-solidus.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Alchemy::Solidus::VERSION
 
-  gem.add_dependency('alchemy_cms', ['>= 4.0.0.beta', '< 5.0'])
-  gem.add_dependency('solidus_core', ['~> 2.0'])
-  gem.add_dependency('solidus_backend', ['~> 2.0'])
+  gem.add_dependency('alchemy_cms', ['>= 4.1.0', '< 5.0'])
+  gem.add_dependency('solidus_core', ['>= 2.6.0', '< 3.0'])
+  gem.add_dependency('solidus_backend', ['>= 2.6.0', '< 3.0'])
   gem.add_dependency('solidus_support', ['>= 0.1.1'])
   gem.add_dependency('deface', ['~> 1.0'])
 

--- a/spec/features/alchemy/alchemy_admin_integrations_spec.rb
+++ b/spec/features/alchemy/alchemy_admin_integrations_spec.rb
@@ -35,6 +35,11 @@ RSpec.feature "Admin Integration", type: :feature do
     expect(page).to have_field 'user_login'
     fill_in 'user_login', with: 'admin'
     fill_in 'user_password', with: 'test1234'
-    click_button Alchemy.version > '4.1.0' ? 'Login' : 'login'
+
+    if Gem::Version.new(Alchemy.version) >= Gem::Version.new('4.2.0')
+      click_button 'Login'
+    else
+      click_button 'login'
+    end
   end
 end


### PR DESCRIPTION
Alchemy 4.1 only works with Solidus 2.6 because of incompatible dependencies (ransack and cancancan).

Since Solidus 2.5 and below are EOL anyways this is an accetable change.