### PR TITLE
Add support for Ransack query params

### DIFF
--- a/app/assets/javascripts/alchemy/solidus/admin/product_select.js
+++ b/app/assets/javascripts/alchemy/solidus/admin/product_select.js
@@ -7,9 +7,9 @@ $.fn.alchemyProductSelect = function(options) {
     ajax: {
       data: function(term, page) {
         return {
-          q: {
+          q: $.extend({
             name_cont: term
-          },
+          }, options.query_params),
           page: page
         }
       },

--- a/app/assets/javascripts/alchemy/solidus/admin/variant_select.js
+++ b/app/assets/javascripts/alchemy/solidus/admin/variant_select.js
@@ -7,9 +7,9 @@ $.fn.alchemyVariantSelect = function(options) {
     ajax: {
       data: function(term, page) {
         return {
-          q: {
+          q: $.extend({
             product_name_or_sku_cont: term
-          },
+          }, options.query_params),
           page: page
         }
       },

--- a/app/views/alchemy/essences/_essence_spree_product_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_spree_product_editor.html.erb
@@ -12,6 +12,7 @@
   $('#<%= content.form_field_id %>').alchemyProductSelect({
     placeholder: "<%= Alchemy.t(:search_product, scope: 'solidus') %>",
     apiToken: "<%= current_alchemy_user.spree_api_key %>",
-    baseUrl: "<%= spree.api_products_path %>"
+    baseUrl: "<%= spree.api_products_path %>",
+    query_params: <%== content.settings[:query_params].to_json %>
   })
 </script>

--- a/app/views/alchemy/essences/_essence_spree_variant_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_spree_variant_editor.html.erb
@@ -12,6 +12,7 @@
   $('#<%= content.form_field_id %>').alchemyVariantSelect({
     placeholder: "<%= Alchemy.t(:search_variant, scope: 'solidus') %>",
     apiToken: "<%= current_alchemy_user.spree_api_key %>",
-    baseUrl: "<%= spree.api_variants_path %>"
+    baseUrl: "<%= spree.api_variants_path %>",
+    query_params: <%== content.settings[:query_params].to_json %>
   })
 </script>


### PR DESCRIPTION
In order to be able to scope the set of products and variants returned by the Solidus API in the essence editor selects we add support for `query_params` in your content settings.