### PR TITLE
Disable ActionView partial path prefixing

### DIFF
--- a/lib/alchemy/solidus/alchemy_in_solidus.rb
+++ b/lib/alchemy/solidus/alchemy_in_solidus.rb
@@ -12,3 +12,7 @@ Rails.application.config.to_prepare do
     Spree::UserSessionsController.include Alchemy::ControllerActions
   end
 end
+
+# Do not prefix element view partials with `spree` namespace.
+# See https://github.com/AlchemyCMS/alchemy_cms/issues/1626
+ActionView::Base.prefix_partial_path_with_controller_namespace = false


### PR DESCRIPTION
If you want to render alchemy elements in a Solidus controller
namespace, we need to disable prefixing of controller path to partial
paths, or we get an extra `spree` namespace for the element partial
paths and the elements wont render.

Closes https://github.com/AlchemyCMS/alchemy_cms/issues/1626