### PR TITLE
Ensure we load controller patches after they load

### DIFF
--- a/lib/alchemy/solidus/alchemy_in_solidus.rb
+++ b/lib/alchemy/solidus/alchemy_in_solidus.rb
@@ -1,14 +1,14 @@
-##
-# If there is the Devise Constant loaded, we can assume that we use it as the authentication method
-# then we set the ParentController of device as the Spree::BaseController
-# https://github.com/AlchemyCMS/alchemy-solidus/issues/10
-if Object.const_defined?("Devise")
-  Devise.setup do |config|
-    config.parent_controller = "Spree::BaseController"
+# Make sure we have everything loaded before patching classes
+Rails.application.config.to_prepare do
+  # Allows to render Alchemy content within Solidus' controller views
+  Spree::BaseController.include Alchemy::ControllerActions
+  Spree::BaseController.include Alchemy::ConfigurationMethods
+
+  # Hook into SolidusAuthDevise controllers if present
+  if defined? Spree::Auth::Engine
+    Spree::UserPasswordsController.include Alchemy::ControllerActions
+    Spree::UserConfirmationsController.include Alchemy::ControllerActions
+    Spree::UserRegistrationsController.include Alchemy::ControllerActions
+    Spree::UserSessionsController.include Alchemy::ControllerActions
   end
 end
-
-# Allow Alchemy content within Solidus views
-Spree::BaseController.send :include, Alchemy::ControllerActions
-Spree::UserSessionsController.send :include, Alchemy::ControllerActions if defined? Spree::UserSessionsController
-Spree::BaseController.send :include, Alchemy::ConfigurationMethods

--- a/lib/alchemy/solidus/use_solidus_layout.rb
+++ b/lib/alchemy/solidus/use_solidus_layout.rb
@@ -1,16 +1,18 @@
-# Include this to make Alchemy render within the Solidus layout
+# Make sure we have everything loaded before patching classes
+Rails.application.config.to_prepare do
+  # Allows to use Solidus helpers within Alchemys controller views
+  Alchemy::BaseHelper.include Spree::BaseHelper
+  Alchemy::BaseHelper.include Spree::CheckoutHelper
+  Alchemy::BaseHelper.include Spree::ProductsHelper
+  Alchemy::BaseHelper.include Spree::StoreHelper
+  Alchemy::BaseHelper.include Spree::TaxonsHelper
 
-Alchemy::BaseHelper.send :include, Spree::BaseHelper
-Alchemy::BaseHelper.send :include, Spree::CheckoutHelper
-Alchemy::BaseHelper.send :include, Spree::ProductsHelper
-Alchemy::BaseHelper.send :include, Spree::StoreHelper
-Alchemy::BaseHelper.send :include, Spree::TaxonsHelper
-
-Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Auth
-Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Common
-Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Order
-Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::PaymentParameters
-Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Pricing
-Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Search
-Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Store
-Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::StrongParameters
+  Alchemy::BaseController.include Spree::Core::ControllerHelpers::Auth
+  Alchemy::BaseController.include Spree::Core::ControllerHelpers::Common
+  Alchemy::BaseController.include Spree::Core::ControllerHelpers::Order
+  Alchemy::BaseController.include Spree::Core::ControllerHelpers::PaymentParameters
+  Alchemy::BaseController.include Spree::Core::ControllerHelpers::Pricing
+  Alchemy::BaseController.include Spree::Core::ControllerHelpers::Search
+  Alchemy::BaseController.include Spree::Core::ControllerHelpers::Store
+  Alchemy::BaseController.include Spree::Core::ControllerHelpers::StrongParameters
+end


### PR DESCRIPTION
The controllers we want to include modules in may not have been loaded the moment we require these files.

Makes it unnecessary to patch the Devise config of Solidus auth devise.