### PR TITLE
Move controller patches into Engines config.to_prepare block

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,25 +178,29 @@ and follow the on screen instructions.
 
 ### Render Alchemy Content in Solidus Layout
 
-If you plan to render the Alchemy site in the Solidus layout add the following
-to your initializer:
+~~If you plan to render the Alchemy site in the Solidus layout add the following
+to your initializer:~~
 
 ```ruby
 # config/initializers/alchemy.rb
 require 'alchemy/solidus/use_solidus_layout'
 ```
 
+**NOTE:** Since v2.5.2 this is done automatically for you. If you upgraded from an older version you can safely remove this from your initializers.
+
 ### Render Alchemy Content in Solidus views
 
-If you plan to render Alchemy content in your Solidus views (ie. a global header
+~~If you plan to render Alchemy content in your Solidus views (ie. a global header
 or footer section), you need to include the Alchemy view helpers and language
 store in your Solidus controllers with the following addition to your
-initializer:
+initializer:~~
 
 ```ruby
 # config/initializers/alchemy.rb
 require 'alchemy/solidus/alchemy_in_solidus'
 ```
+
+**NOTE:** Since v2.5.2 this is done automatically for you. If you upgraded from an older version you can safely remove this from your initializers.
 
 ### Routing
 

--- a/lib/alchemy/solidus/alchemy_in_solidus.rb
+++ b/lib/alchemy/solidus/alchemy_in_solidus.rb
@@ -1,16 +1,15 @@
-# Make sure we have everything loaded before patching classes
-Rails.application.config.to_prepare do
-  # Allows to render Alchemy content within Solidus' controller views
-  Spree::BaseController.include Alchemy::ControllerActions
-  Spree::BaseController.include Alchemy::ConfigurationMethods
+# Allows to render Alchemy content within Solidus' controller views
+Spree::StoreController.include(
+  Alchemy::ControllerActions,
+  Alchemy::ConfigurationMethods
+)
 
-  # Hook into SolidusAuthDevise controllers if present
-  if defined? Spree::Auth::Engine
-    Spree::UserPasswordsController.include Alchemy::ControllerActions
-    Spree::UserConfirmationsController.include Alchemy::ControllerActions
-    Spree::UserRegistrationsController.include Alchemy::ControllerActions
-    Spree::UserSessionsController.include Alchemy::ControllerActions
-  end
+# Hook into SolidusAuthDevise controllers if present
+if defined? Spree::Auth::Engine
+  Spree::UserPasswordsController.include Alchemy::ControllerActions
+  Spree::UserConfirmationsController.include Alchemy::ControllerActions
+  Spree::UserRegistrationsController.include Alchemy::ControllerActions
+  Spree::UserSessionsController.include Alchemy::ControllerActions
 end
 
 # Do not prefix element view partials with `spree` namespace.

--- a/lib/alchemy/solidus/engine.rb
+++ b/lib/alchemy/solidus/engine.rb
@@ -27,6 +27,14 @@ module Alchemy
           require 'alchemy/solidus/spree_custom_user_generator_fix'
           require 'alchemy/solidus/spree_install_generator_fix'
         end
+
+        if SolidusSupport.frontend_available?
+          # Allows to render Alchemy content within Solidus' controller views
+          require_dependency 'alchemy/solidus/alchemy_in_solidus'
+        end
+
+        # Allows to use Solidus helpers within Alchemys controller views
+        require_dependency 'alchemy/solidus/use_solidus_layout'
       end
 
       # Fix for +belongs_to :bill_address+ in {Spree::UserAddressBook}
@@ -38,7 +46,7 @@ module Alchemy
           end
         end
       end
-      
+
       # In versions of Solidus prior to 2.8, we override the tabs partial
       # to pass a match_path value to each tab. (Version 2.8 is already
       # passing this option.) This option is used to configure the paths

--- a/lib/alchemy/solidus/use_solidus_layout.rb
+++ b/lib/alchemy/solidus/use_solidus_layout.rb
@@ -1,18 +1,19 @@
-# Make sure we have everything loaded before patching classes
-Rails.application.config.to_prepare do
-  # Allows to use Solidus helpers within Alchemys controller views
-  Alchemy::BaseHelper.include Spree::BaseHelper
-  Alchemy::BaseHelper.include Spree::CheckoutHelper
-  Alchemy::BaseHelper.include Spree::ProductsHelper
-  Alchemy::BaseHelper.include Spree::StoreHelper
-  Alchemy::BaseHelper.include Spree::TaxonsHelper
+# Allows to use Solidus helpers within Alchemys controller views
+Alchemy::BaseHelper.include(
+  Spree::BaseHelper,
+  Spree::CheckoutHelper,
+  Spree::ProductsHelper,
+  Spree::StoreHelper,
+  Spree::TaxonsHelper
+)
 
-  Alchemy::BaseController.include Spree::Core::ControllerHelpers::Auth
-  Alchemy::BaseController.include Spree::Core::ControllerHelpers::Common
-  Alchemy::BaseController.include Spree::Core::ControllerHelpers::Order
-  Alchemy::BaseController.include Spree::Core::ControllerHelpers::PaymentParameters
-  Alchemy::BaseController.include Spree::Core::ControllerHelpers::Pricing
-  Alchemy::BaseController.include Spree::Core::ControllerHelpers::Search
-  Alchemy::BaseController.include Spree::Core::ControllerHelpers::Store
-  Alchemy::BaseController.include Spree::Core::ControllerHelpers::StrongParameters
-end
+Alchemy::BaseController.include(
+  Spree::Core::ControllerHelpers::Auth,
+  Spree::Core::ControllerHelpers::Common,
+  Spree::Core::ControllerHelpers::Order,
+  Spree::Core::ControllerHelpers::PaymentParameters,
+  Spree::Core::ControllerHelpers::Pricing,
+  Spree::Core::ControllerHelpers::Search,
+  Spree::Core::ControllerHelpers::Store,
+  Spree::Core::ControllerHelpers::StrongParameters
+)


### PR DESCRIPTION
Letting the Rails app do the reload leads to not loading the files during local development at all.