### PR TITLE
Install solidus_frontend during tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 solidus_branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem "solidus_core", github: "solidusio/solidus", branch: solidus_branch
+gem "solidus_frontend", github: "solidusio/solidus", branch: solidus_branch
 gem "solidus_backend", github: "solidusio/solidus", branch: solidus_branch
 
 alchemy_branch = ENV.fetch('ALCHEMY_BRANCH', 'master')


### PR DESCRIPTION
Out of sudden the admin integration spec fails because the `spree.root_path` is not available anymore.

Weirdly enough the `respond_to?` should guard this, but it is not working. Rails magic \o/