### PR TITLE
Use user_class#name

### DIFF
--- a/lib/alchemy/solidus/engine.rb
+++ b/lib/alchemy/solidus/engine.rb
@@ -12,12 +12,12 @@ module Alchemy
         Alchemy.register_ability ::Spree::Ability
         ::Spree::Ability.register_ability ::Alchemy::Permissions
 
-        if Alchemy.user_class_name == 'Spree::User'
+        if Alchemy.user_class.name == 'Spree::User'
           require 'alchemy/solidus/spree_user_extension'
           Spree::User.include Alchemy::Solidus::SpreeUserExtension
         end
 
-        if Alchemy.user_class_name == 'Alchemy::User'
+        if Alchemy.user_class.name == 'Alchemy::User'
           require 'alchemy/solidus/alchemy_user_extension'
           Alchemy::User.include Alchemy::Solidus::AlchemyUserExtension
           require 'alchemy/solidus/spree_admin_unauthorized_redirect'
@@ -40,7 +40,7 @@ module Alchemy
       # Fix for +belongs_to :bill_address+ in {Spree::UserAddressBook}
       # Solidus has this set to +false+ in {Spree::Base}, but {Alchemy::User} does not inherit from it.
       initializer 'alchemy_solidus.belongs_bill_address_fix' do
-        if Alchemy.user_class_name == 'Alchemy::User'
+        if Alchemy.user_class.name == 'Alchemy::User'
           ActiveSupport.on_load(:active_record) do
             Alchemy::User.belongs_to_required_by_default = false
           end

--- a/lib/alchemy/solidus/spree_admin_unauthorized_redirect.rb
+++ b/lib/alchemy/solidus/spree_admin_unauthorized_redirect.rb
@@ -4,6 +4,6 @@ Spree::Admin::BaseController.unauthorized_redirect = -> do
     redirect_to spree.root_path
   else
     store_location
-    redirect_to alchemy.login_path
+    redirect_to Alchemy.login_path
   end
 end


### PR DESCRIPTION
Alchemy 4.4.2 has a fix for constant lookup issues (https://github.com/AlchemyCMS/alchemy_cms/pull/1724/)

That prefixes the user class with `::`

In order to be compatible with older Alchemy versions we use the `class#name` instead.