### PR TITLE
Build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: trusty
+dist: bionic
 sudo: false
 cache:
   bundler: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,13 @@ rvm:
   - 2.5.5
 env:
   matrix:
-    - ALCHEMY_BRANCH=4.1-stable
-    - ALCHEMY_BRANCH=4.2-stable
-    - ALCHEMY_BRANCH=4.3-stable
+    - ALCHEMY_BRANCH=4.4-stable
+    - ALCHEMY_BRANCH=4.5-stable
+    - ALCHEMY_BRANCH=4.6-stable
     - ALCHEMY_BRANCH=master
-    - SOLIDUS_BRANCH=v2.6
-    - SOLIDUS_BRANCH=v2.7
     - SOLIDUS_BRANCH=v2.8
     - SOLIDUS_BRANCH=v2.9
+    - SOLIDUS_BRANCH=v2.10
     - SOLIDUS_BRANCH=master
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 cache:
   bundler: true
 rvm:
-  - 2.5.5
+  - 2.6
 env:
   matrix:
     - ALCHEMY_BRANCH=4.4-stable

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "solidus_backend", github: "solidusio/solidus", branch: solidus_branch
 
 alchemy_branch = ENV.fetch('ALCHEMY_BRANCH', 'master')
 gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: alchemy_branch
-gem 'alchemy-devise', github: "AlchemyCMS/alchemy-devise", branch: alchemy_branch
+gem 'alchemy-devise', github: "AlchemyCMS/alchemy-devise", branch: 'master'
 
 # Specify your gem's dependencies in alchemy-solidus.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ task :test_setup do
     system <<-SETUP.strip_heredoc
       export RAILS_ENV=test && \
       bin/rake db:environment:set db:drop && \
-      bin/rails g spree:install --force --quiet --auto-accept --no-seed --no-sample && \
+      bin/rails g spree:install --force --auto-accept --no-seed --no-sample && \
       bin/rails g alchemy:solidus:install --auto-accept --force
     SETUP
     exit($?.exitstatus) unless $?.success?

--- a/lib/generators/alchemy/solidus/install/install_generator.rb
+++ b/lib/generators/alchemy/solidus/install/install_generator.rb
@@ -1,7 +1,7 @@
 require 'rails/generators'
 require 'alchemy/version'
 
-if Alchemy.gem_version >= Gem::Version.new("5.0.0a")
+if Alchemy.gem_version >= Gem::Version.new("5.0.0.a")
   require 'generators/alchemy/install/install_generator'
 else
   require 'rails/generators/alchemy/install/install_generator'

--- a/lib/generators/alchemy/solidus/install/install_generator.rb
+++ b/lib/generators/alchemy/solidus/install/install_generator.rb
@@ -1,5 +1,12 @@
 require 'rails/generators'
-require 'rails/generators/alchemy/install/install_generator'
+require 'alchemy/version'
+
+if Alchemy.gem_version >= Gem::Version.new("5.0.0a")
+  require 'generators/alchemy/install/install_generator'
+else
+  require 'rails/generators/alchemy/install/install_generator'
+end
+
 require 'generators/spree/custom_user/custom_user_generator'
 require 'solidus_support'
 
@@ -83,14 +90,17 @@ module Alchemy
             password = ask("Enter the password for the admin user", default: password)
           end
 
+          # This is a bit strange, but without the double save this fails with a failed validation.
           Alchemy::User.create!(
             login: login,
             email: email,
             password: password,
             password_confirmation: password,
-            alchemy_roles: 'admin',
-            spree_roles: [Spree::Role.find_or_create_by!(name: 'admin')]
-          )
+            alchemy_roles: 'admin'
+          ).tap do |user|
+            user.spree_roles = [Spree::Role.find_or_create_by!(name: 'admin')]
+            user.save!
+          end
         end
       end
 

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -12,13 +12,10 @@ require "alchemy-solidus"
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.1 if config.respond_to? :load_defaults
+    config.load_defaults 5.2
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
-    if config.active_record.sqlite3.respond_to?(:represent_boolean_as_integer=)
-      config.active_record.sqlite3.represent_boolean_as_integer = true
-    end
   end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,2 +1,7 @@
 Rails.application.routes.draw do
+  # Let AlchemyCMS handle the root route
+  root to: 'alchemy/pages#index'
+
+  mount Spree::Core::Engine, at: "/"
+  mount Alchemy::Engine, at: '/'
 end

--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "dummy",
-  "private": true,
-  "dependencies": {}
-}

--- a/spec/views/alchemy/essences/essence_spree_product_editor_spec.rb
+++ b/spec/views/alchemy/essences/essence_spree_product_editor_spec.rb
@@ -3,12 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe 'alchemy/essences/_essence_spree_product_editor' do
-  let(:content) { Alchemy::Content.new(essence: essence) }
+  let(:content) do
+    content = Alchemy::Content.new(essence: essence)
+    if Alchemy.gem_version >= Gem::Version.new("4.9")
+      Alchemy::ContentEditor.new(content)
+    else
+      content
+    end
+  end
+
   let(:essence) { Alchemy::EssenceSpreeProduct.new }
 
   before do
-    view.class.send(:include, Alchemy::Admin::EssencesHelper)
-    allow(view).to receive(:content_label) { content.name }
+    view.class.send(:include, Alchemy::Admin::ElementsHelper)
+    expect(view).to receive(:content_label) { content.name }
   end
 
   subject do

--- a/spec/views/alchemy/essences/essence_spree_taxon_editor_spec.rb
+++ b/spec/views/alchemy/essences/essence_spree_taxon_editor_spec.rb
@@ -3,11 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe 'alchemy/essences/_essence_spree_taxon_editor' do
-  let(:content) { Alchemy::Content.new(essence: essence) }
+  let(:content) do
+    content = Alchemy::Content.new(essence: essence)
+    if Alchemy.gem_version >= Gem::Version.new("4.9")
+      Alchemy::ContentEditor.new(content)
+    else
+      content
+    end
+  end
   let(:essence) { Alchemy::EssenceSpreeTaxon.new }
 
   before do
-    view.class.send(:include, Alchemy::Admin::EssencesHelper)
+    view.class.send(:include,Alchemy::Admin::ElementsHelper)
     allow(view).to receive(:content_label) { content.name }
   end
 

--- a/spec/views/alchemy/essences/essence_spree_variant_editor_spec.rb
+++ b/spec/views/alchemy/essences/essence_spree_variant_editor_spec.rb
@@ -3,11 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe 'alchemy/essences/_essence_spree_variant_editor' do
-  let(:content) { Alchemy::Content.new(essence: essence) }
+  let(:content) do
+    content = Alchemy::Content.new(essence: essence)
+    if Alchemy.gem_version >= Gem::Version.new("4.9")
+      Alchemy::ContentEditor.new(content)
+    else
+      content
+    end
+  end
   let(:essence) { Alchemy::EssenceSpreeVariant.new }
 
   before do
-    view.class.send(:include, Alchemy::Admin::EssencesHelper)
+    view.class.send(:include, Alchemy::Admin::ElementsHelper)
     allow(view).to receive(:content_label) { content.name }
   end
 


### PR DESCRIPTION
This fixes the install generator (require the correct file from Alchemy 5, and fix a bizarre validation error when creating the admin user) and includes the correct view helper in our view specs.

It also fixes the branch of `alchemy-devise` to always be `master`. Alchemy Devise doesn't do a lot, and importantly runs specs for the past three Alchemy versions on its own. 

We also upgrade the Travis image to Ubuntu 18.04 for an up-to-date node version. 