### PR TITLE
Fix essence editor partials for elements w/o editor

### DIFF
--- a/app/views/alchemy/essences/_essence_spree_product_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_spree_product_editor.html.erb
@@ -1,3 +1,5 @@
+<% content ||= local_assigns[:content] || local_assigns[:essence_spree_product_editor] %>
+
 <div class="content_editor essence_spree_product" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
   <%= content_label(content) %>
   <%= text_field_tag(

--- a/app/views/alchemy/essences/_essence_spree_taxon_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_spree_taxon_editor.html.erb
@@ -1,3 +1,5 @@
+<% content ||= local_assigns[:content] || local_assigns[:essence_spree_taxon_editor] %>
+
 <div class="content_editor essence_spree_taxon" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
   <%= content_label(content) %>
   <%= text_field_tag(

--- a/app/views/alchemy/essences/_essence_spree_variant_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_spree_variant_editor.html.erb
@@ -1,3 +1,5 @@
+<% content ||= local_assigns[:content] || local_assigns[:essence_spree_variant_editor] %>
+
 <div class="content_editor essence_spree_variant" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
   <%= content_label(content) %>
   <%= text_field_tag(

--- a/spec/views/alchemy/essences/essence_spree_product_editor_spec.rb
+++ b/spec/views/alchemy/essences/essence_spree_product_editor_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'alchemy/essences/_essence_spree_product_editor' do
+RSpec.describe "alchemy/essences/_essence_spree_product_editor" do
   let(:content) do
     content = Alchemy::Content.new(essence: essence)
     if Alchemy.gem_version >= Gem::Version.new("4.9")
@@ -20,18 +20,18 @@ RSpec.describe 'alchemy/essences/_essence_spree_product_editor' do
   end
 
   subject do
-    render 'alchemy/essences/essence_spree_product_editor',
+    render "alchemy/essences/essence_spree_product_editor",
       content: content,
-      spree: double(api_products_path: '/api/products'),
-      current_alchemy_user: double(spree_api_key: '123')
+      spree: double(api_products_path: "/api/products"),
+      current_alchemy_user: double(spree_api_key: "123")
     rendered
   end
 
   it "renders a product input" do
-    is_expected.to have_css('input.alchemy_selectbox.full_width')
+    is_expected.to have_css("input.alchemy_selectbox.full_width")
   end
 
-  context 'with a product related to essence' do
+  context "with a product related to essence" do
     let(:product) { Spree::Product.new(id: 1) }
     let(:essence) { Alchemy::EssenceSpreeProduct.new(spree_product_id: product.id) }
 

--- a/spec/views/alchemy/essences/essence_spree_product_editor_spec.rb
+++ b/spec/views/alchemy/essences/essence_spree_product_editor_spec.rb
@@ -19,24 +19,49 @@ RSpec.describe "alchemy/essences/_essence_spree_product_editor" do
     expect(view).to receive(:content_label) { content.name }
   end
 
-  subject do
-    render "alchemy/essences/essence_spree_product_editor",
-      content: content,
-      spree: double(api_products_path: "/api/products"),
-      current_alchemy_user: double(spree_api_key: "123")
-    rendered
+  context "with local named content" do
+    subject do
+      render "alchemy/essences/essence_spree_product_editor",
+        content: content,
+        spree: double(api_products_path: "/api/products"),
+        current_alchemy_user: double(spree_api_key: "123")
+      rendered
+    end
+
+    it "renders a product input" do
+      is_expected.to have_css("input.alchemy_selectbox.full_width")
+    end
+
+    context "with a product related to essence" do
+      let(:product) { Spree::Product.new(id: 1) }
+      let(:essence) { Alchemy::EssenceSpreeProduct.new(spree_product_id: product.id) }
+
+      it "sets product id as value" do
+        is_expected.to have_css('input.alchemy_selectbox[value="1"]')
+      end
+    end
   end
 
-  it "renders a product input" do
-    is_expected.to have_css("input.alchemy_selectbox.full_width")
-  end
+  context "with local named essence_spree_product_editor" do
+    subject do
+      render "alchemy/essences/essence_spree_product_editor",
+        essence_spree_product_editor: content,
+        spree: double(api_products_path: "/api/products"),
+        current_alchemy_user: double(spree_api_key: "123")
+      rendered
+    end
 
-  context "with a product related to essence" do
-    let(:product) { Spree::Product.new(id: 1) }
-    let(:essence) { Alchemy::EssenceSpreeProduct.new(spree_product_id: product.id) }
+    it "renders a product input" do
+      is_expected.to have_css("input.alchemy_selectbox.full_width")
+    end
 
-    it "sets product id as value" do
-      is_expected.to have_css('input.alchemy_selectbox[value="1"]')
+    context "with a product related to essence" do
+      let(:product) { Spree::Product.new(id: 1) }
+      let(:essence) { Alchemy::EssenceSpreeProduct.new(spree_product_id: product.id) }
+
+      it "sets product id as value" do
+        is_expected.to have_css('input.alchemy_selectbox[value="1"]')
+      end
     end
   end
 end

--- a/spec/views/alchemy/essences/essence_spree_taxon_editor_spec.rb
+++ b/spec/views/alchemy/essences/essence_spree_taxon_editor_spec.rb
@@ -18,24 +18,49 @@ RSpec.describe "alchemy/essences/_essence_spree_taxon_editor" do
     allow(view).to receive(:content_label) { content.name }
   end
 
-  subject do
-    render "alchemy/essences/essence_spree_taxon_editor",
-      content: content,
-      spree: double(api_taxons_path: "/api/taxons"),
-      current_alchemy_user: double(spree_api_key: "123")
-    rendered
+  context "with local named content" do
+    subject do
+      render "alchemy/essences/essence_spree_taxon_editor",
+        content: content,
+        spree: double(api_taxons_path: "/api/taxons"),
+        current_alchemy_user: double(spree_api_key: "123")
+      rendered
+    end
+
+    it "renders a taxon input" do
+      is_expected.to have_css("input.alchemy_selectbox.full_width")
+    end
+
+    context "with a taxon related to essence" do
+      let(:taxon) { Spree::Taxon.new(id: 1) }
+      let(:essence) { Alchemy::EssenceSpreeTaxon.new(taxon_id: taxon.id) }
+
+      it "sets taxon id as value" do
+        is_expected.to have_css('input.alchemy_selectbox[value="1"]')
+      end
+    end
   end
 
-  it "renders a taxon input" do
-    is_expected.to have_css("input.alchemy_selectbox.full_width")
-  end
+  context "with local named essence_spree_taxon_editor" do
+    subject do
+      render "alchemy/essences/essence_spree_taxon_editor",
+        essence_spree_taxon_editor: content,
+        spree: double(api_taxons_path: "/api/taxons"),
+        current_alchemy_user: double(spree_api_key: "123")
+      rendered
+    end
 
-  context "with a taxon related to essence" do
-    let(:taxon) { Spree::Taxon.new(id: 1) }
-    let(:essence) { Alchemy::EssenceSpreeTaxon.new(taxon_id: taxon.id) }
+    it "renders a taxon input" do
+      is_expected.to have_css("input.alchemy_selectbox.full_width")
+    end
 
-    it "sets taxon id as value" do
-      is_expected.to have_css('input.alchemy_selectbox[value="1"]')
+    context "with a taxon related to essence" do
+      let(:taxon) { Spree::Taxon.new(id: 1) }
+      let(:essence) { Alchemy::EssenceSpreeTaxon.new(taxon_id: taxon.id) }
+
+      it "sets taxon id as value" do
+        is_expected.to have_css('input.alchemy_selectbox[value="1"]')
+      end
     end
   end
 end

--- a/spec/views/alchemy/essences/essence_spree_taxon_editor_spec.rb
+++ b/spec/views/alchemy/essences/essence_spree_taxon_editor_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'alchemy/essences/_essence_spree_taxon_editor' do
+RSpec.describe "alchemy/essences/_essence_spree_taxon_editor" do
   let(:content) do
     content = Alchemy::Content.new(essence: essence)
     if Alchemy.gem_version >= Gem::Version.new("4.9")
@@ -14,23 +14,23 @@ RSpec.describe 'alchemy/essences/_essence_spree_taxon_editor' do
   let(:essence) { Alchemy::EssenceSpreeTaxon.new }
 
   before do
-    view.class.send(:include,Alchemy::Admin::ElementsHelper)
+    view.class.send(:include, Alchemy::Admin::ElementsHelper)
     allow(view).to receive(:content_label) { content.name }
   end
 
   subject do
-    render 'alchemy/essences/essence_spree_taxon_editor',
+    render "alchemy/essences/essence_spree_taxon_editor",
       content: content,
-      spree: double(api_taxons_path: '/api/taxons'),
-      current_alchemy_user: double(spree_api_key: '123')
+      spree: double(api_taxons_path: "/api/taxons"),
+      current_alchemy_user: double(spree_api_key: "123")
     rendered
   end
 
   it "renders a taxon input" do
-    is_expected.to have_css('input.alchemy_selectbox.full_width')
+    is_expected.to have_css("input.alchemy_selectbox.full_width")
   end
 
-  context 'with a taxon related to essence' do
+  context "with a taxon related to essence" do
     let(:taxon) { Spree::Taxon.new(id: 1) }
     let(:essence) { Alchemy::EssenceSpreeTaxon.new(taxon_id: taxon.id) }
 

--- a/spec/views/alchemy/essences/essence_spree_variant_editor_spec.rb
+++ b/spec/views/alchemy/essences/essence_spree_variant_editor_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'alchemy/essences/_essence_spree_variant_editor' do
+RSpec.describe "alchemy/essences/_essence_spree_variant_editor" do
   let(:content) do
     content = Alchemy::Content.new(essence: essence)
     if Alchemy.gem_version >= Gem::Version.new("4.9")
@@ -19,19 +19,19 @@ RSpec.describe 'alchemy/essences/_essence_spree_variant_editor' do
   end
 
   subject do
-    render 'alchemy/essences/essence_spree_variant_editor',
+    render "alchemy/essences/essence_spree_variant_editor",
       content: content,
-      spree: double(api_variants_path: '/api/variants'),
-      current_alchemy_user: double(spree_api_key: '123')
+      spree: double(api_variants_path: "/api/variants"),
+      current_alchemy_user: double(spree_api_key: "123")
     rendered
   end
 
   it "renders a variant input" do
-    is_expected.to have_css('input.alchemy_selectbox.full_width')
+    is_expected.to have_css("input.alchemy_selectbox.full_width")
   end
 
-  context 'with a variant related to essence' do
-    let(:product) { Spree::Product.new(name: 'Chocolate') }
+  context "with a variant related to essence" do
+    let(:product) { Spree::Product.new(name: "Chocolate") }
     let(:variant) { Spree::Variant.new(id: 1, product: product) }
     let(:essence) { Alchemy::EssenceSpreeVariant.new(variant_id: variant.id) }
 

--- a/spec/views/alchemy/essences/essence_spree_variant_editor_spec.rb
+++ b/spec/views/alchemy/essences/essence_spree_variant_editor_spec.rb
@@ -18,25 +18,51 @@ RSpec.describe "alchemy/essences/_essence_spree_variant_editor" do
     allow(view).to receive(:content_label) { content.name }
   end
 
-  subject do
-    render "alchemy/essences/essence_spree_variant_editor",
-      content: content,
-      spree: double(api_variants_path: "/api/variants"),
-      current_alchemy_user: double(spree_api_key: "123")
-    rendered
+  context "with local named content" do
+    subject do
+      render "alchemy/essences/essence_spree_variant_editor",
+        content: content,
+        spree: double(api_variants_path: "/api/variants"),
+        current_alchemy_user: double(spree_api_key: "123")
+      rendered
+    end
+
+    it "renders a variant input" do
+      is_expected.to have_css("input.alchemy_selectbox.full_width")
+    end
+
+    context "with a variant related to essence" do
+      let(:product) { Spree::Product.new(name: "Chocolate") }
+      let(:variant) { Spree::Variant.new(id: 1, product: product) }
+      let(:essence) { Alchemy::EssenceSpreeVariant.new(variant_id: variant.id) }
+
+      it "sets variant id as value" do
+        is_expected.to have_css('input.alchemy_selectbox[value="1"]')
+      end
+    end
   end
 
-  it "renders a variant input" do
-    is_expected.to have_css("input.alchemy_selectbox.full_width")
-  end
+  context "with local named essence_spree_variant_editor" do
+    subject do
+      render "alchemy/essences/essence_spree_variant_editor",
+        essence_spree_variant_editor: content,
+        spree: double(api_variants_path: "/api/variants"),
+        current_alchemy_user: double(spree_api_key: "123")
+      rendered
+    end
 
-  context "with a variant related to essence" do
-    let(:product) { Spree::Product.new(name: "Chocolate") }
-    let(:variant) { Spree::Variant.new(id: 1, product: product) }
-    let(:essence) { Alchemy::EssenceSpreeVariant.new(variant_id: variant.id) }
+    it "renders a variant input" do
+      is_expected.to have_css("input.alchemy_selectbox.full_width")
+    end
 
-    it "sets variant id as value" do
-      is_expected.to have_css('input.alchemy_selectbox[value="1"]')
+    context "with a variant related to essence" do
+      let(:product) { Spree::Product.new(name: "Chocolate") }
+      let(:variant) { Spree::Variant.new(id: 1, product: product) }
+      let(:essence) { Alchemy::EssenceSpreeVariant.new(variant_id: variant.id) }
+
+      it "sets variant id as value" do
+        is_expected.to have_css('input.alchemy_selectbox[value="1"]')
+      end
     end
   end
 end


### PR DESCRIPTION
If an element editor is not present (default in Alchemy 5.0) the local variable is named after Rails defaults (the partial name).