### PR TITLE
Fix deprecated solidus_gem_version references

### DIFF
--- a/lib/alchemy/solidus/engine.rb
+++ b/lib/alchemy/solidus/engine.rb
@@ -23,7 +23,7 @@ module Alchemy
           require 'alchemy/solidus/spree_admin_unauthorized_redirect'
         end
 
-        if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5')
+        if Spree.solidus_gem_version < Gem::Version.new('2.5')
           require 'alchemy/solidus/spree_custom_user_generator_fix'
           require 'alchemy/solidus/spree_install_generator_fix'
         end

--- a/lib/generators/alchemy/solidus/install/install_generator.rb
+++ b/lib/generators/alchemy/solidus/install/install_generator.rb
@@ -55,7 +55,7 @@ module Alchemy
           arguments = options[:auto_accept] ? ['Alchemy::User', '--force'] : ['Alchemy::User']
           Spree::CustomUserGenerator.start(arguments)
           gsub_file 'lib/spree/authentication_helpers.rb', /main_app\./, 'Alchemy.'
-          if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.0')
+          if Spree.solidus_gem_version < Gem::Version.new('2.5.0')
             gsub_file 'config/initializers/spree.rb', /Spree\.user_class.?=.?.+$/, 'Spree.user_class = "Alchemy::User"'
           end
           rake('db:migrate', abort_on_failure: true)


### PR DESCRIPTION
`SolidusSupport.solidus_gem_version` is deprecated and will be removed in solidus_support 1.0