### PR TITLE
Use Alchemy.user_class_name

### DIFF
--- a/lib/alchemy/solidus/engine.rb
+++ b/lib/alchemy/solidus/engine.rb
@@ -12,12 +12,12 @@ module Alchemy
         Alchemy.register_ability ::Spree::Ability
         ::Spree::Ability.register_ability ::Alchemy::Permissions
 
-        if Alchemy.user_class.name == 'Spree::User'
+        if Alchemy.user_class_name == '::Spree::User'
           require 'alchemy/solidus/spree_user_extension'
           Spree::User.include Alchemy::Solidus::SpreeUserExtension
         end
 
-        if Alchemy.user_class.name == 'Alchemy::User'
+        if Alchemy.user_class_name == '::Alchemy::User'
           require 'alchemy/solidus/alchemy_user_extension'
           Alchemy::User.include Alchemy::Solidus::AlchemyUserExtension
           require 'alchemy/solidus/spree_admin_unauthorized_redirect'
@@ -40,7 +40,7 @@ module Alchemy
       # Fix for +belongs_to :bill_address+ in {Spree::UserAddressBook}
       # Solidus has this set to +false+ in {Spree::Base}, but {Alchemy::User} does not inherit from it.
       initializer 'alchemy_solidus.belongs_bill_address_fix' do
-        if Alchemy.user_class.name == 'Alchemy::User'
+        if Alchemy.user_class_name == '::Alchemy::User'
           ActiveSupport.on_load(:active_record) do
             Alchemy::User.belongs_to_required_by_default = false
           end


### PR DESCRIPTION
We must not expect an `Alchemy.user_class` to exist during boot.
Use the `user_class_name` String to decide what we need to do.

This helps to avoid problems booting the Rails app if the
`Alchemy.user_class` has not been set yet.