### PR TITLE
Allow to save empty taxons, products and variants

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-solidus_branch = ENV.fetch("SOLIDUS_BRANCH", "master")
+solidus_branch = ENV.fetch("SOLIDUS_BRANCH", "v2.11")
 gem "solidus_core", github: "solidusio/solidus", branch: solidus_branch
 gem "solidus_frontend", github: "solidusio/solidus", branch: solidus_branch
 gem "solidus_backend", github: "solidusio/solidus", branch: solidus_branch

--- a/Gemfile
+++ b/Gemfile
@@ -1,17 +1,17 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-solidus_branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
+solidus_branch = ENV.fetch("SOLIDUS_BRANCH", "master")
 gem "solidus_core", github: "solidusio/solidus", branch: solidus_branch
 gem "solidus_frontend", github: "solidusio/solidus", branch: solidus_branch
 gem "solidus_backend", github: "solidusio/solidus", branch: solidus_branch
 
-alchemy_branch = ENV.fetch('ALCHEMY_BRANCH', 'main')
+alchemy_branch = ENV.fetch("ALCHEMY_BRANCH", "main")
 gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: alchemy_branch
-gem 'alchemy-devise', github: "AlchemyCMS/alchemy-devise", branch: 'main'
+gem "alchemy-devise", github: "AlchemyCMS/alchemy-devise", branch: "main"
 
 # Specify your gem's dependencies in alchemy-solidus.gemspec
 gemspec
 
-gem 'sqlite3'
-gem 'pry-rails'
-gem 'sprockets', '< 4'
+gem "sqlite3"
+gem "pry-rails"
+gem "sprockets", "< 4"

--- a/app/models/alchemy/essence_spree_product.rb
+++ b/app/models/alchemy/essence_spree_product.rb
@@ -13,7 +13,7 @@ module Alchemy
 
     def ingredient=(product_or_id)
       case product_or_id
-      when PRODUCT_ID
+      when PRODUCT_ID, ""
         self.spree_product_id = product_or_id
       when Spree::Product
         self.product = product_or_id

--- a/app/models/alchemy/essence_spree_product.rb
+++ b/app/models/alchemy/essence_spree_product.rb
@@ -4,8 +4,10 @@ module Alchemy
   class EssenceSpreeProduct < ActiveRecord::Base
     PRODUCT_ID = /\A\d+\z/
 
-    belongs_to :product, class_name: 'Spree::Product',
-      optional: true, foreign_key: 'spree_product_id'
+    belongs_to :product,
+      class_name: "Spree::Product",
+      optional: true,
+      foreign_key: "spree_product_id"
 
     acts_as_essence(ingredient_column: :product)
 

--- a/app/models/alchemy/essence_spree_taxon.rb
+++ b/app/models/alchemy/essence_spree_taxon.rb
@@ -13,7 +13,7 @@ module Alchemy
 
     def ingredient=(taxon_or_id)
       case taxon_or_id
-      when TAXON_ID
+      when TAXON_ID, ""
         self.taxon_id = taxon_or_id
       when Spree::Taxon
         self.taxon = taxon_or_id

--- a/app/models/alchemy/essence_spree_taxon.rb
+++ b/app/models/alchemy/essence_spree_taxon.rb
@@ -4,8 +4,10 @@ module Alchemy
   class EssenceSpreeTaxon < ActiveRecord::Base
     TAXON_ID = /\A\d+\z/
 
-    belongs_to :taxon, class_name: 'Spree::Taxon',
-      optional: true, foreign_key: 'taxon_id'
+    belongs_to :taxon,
+      class_name: "Spree::Taxon",
+      optional: true,
+      foreign_key: "taxon_id"
 
     acts_as_essence(ingredient_column: :taxon)
 

--- a/app/models/alchemy/essence_spree_variant.rb
+++ b/app/models/alchemy/essence_spree_variant.rb
@@ -4,7 +4,9 @@ module Alchemy
   class EssenceSpreeVariant < ActiveRecord::Base
     VARIANT_ID = /\A\d+\z/
 
-    belongs_to :variant, class_name: 'Spree::Variant', optional: true
+    belongs_to :variant,
+      class_name: "Spree::Variant",
+      optional: true
 
     acts_as_essence(ingredient_column: :variant)
 

--- a/app/models/alchemy/essence_spree_variant.rb
+++ b/app/models/alchemy/essence_spree_variant.rb
@@ -12,7 +12,7 @@ module Alchemy
 
     def ingredient=(variant_or_id)
       case variant_or_id
-      when VARIANT_ID
+      when VARIANT_ID, ""
         self.variant_id = variant_or_id
       when Spree::Variant
         self.variant = variant_or_id

--- a/spec/models/alchemy/essence_spree_product_spec.rb
+++ b/spec/models/alchemy/essence_spree_product_spec.rb
@@ -1,45 +1,45 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require 'alchemy/test_support/essence_shared_examples'
+require "rails_helper"
+require "alchemy/test_support/essence_shared_examples"
 
-require_dependency 'alchemy/site'
+require_dependency "alchemy/site"
 
 RSpec.describe Alchemy::EssenceSpreeProduct, type: :model do
   let(:product) { build_stubbed(:product) }
   let(:essence) { described_class.new(product: product) }
 
-  it_behaves_like 'an essence' do
+  it_behaves_like "an essence" do
     let(:ingredient_value) { product }
   end
 
-  describe 'ingredient=' do
-    context 'when String value is only a number' do
-      let(:value) { '101' }
+  describe "ingredient=" do
+    context "when String value is only a number" do
+      let(:value) { "101" }
 
       before do
         essence.ingredient = value
       end
 
-      it 'sets spree_product_id with that id' do
+      it "sets spree_product_id with that id" do
         expect(essence.spree_product_id).to eq(101)
       end
     end
 
-    context 'when value is an Spree Variant' do
+    context "when value is an Spree Variant" do
       let(:value) { product }
 
       before do
         essence.ingredient = value
       end
 
-      it 'sets product to that product' do
+      it "sets product to that product" do
         expect(essence.product).to eq(product)
       end
     end
 
-    context 'when value is not only a number' do
-      let(:value) { 'product1' }
+    context "when value is not only a number" do
+      let(:value) { "product1" }
 
       it do
         expect {
@@ -49,10 +49,10 @@ RSpec.describe Alchemy::EssenceSpreeProduct, type: :model do
     end
   end
 
-  describe '#preview_text' do
+  describe "#preview_text" do
     subject { essence.preview_text(nil) }
 
-    it 'returns the products name' do
+    it "returns the products name" do
       is_expected.to eq(product.name)
     end
   end

--- a/spec/models/alchemy/essence_spree_product_spec.rb
+++ b/spec/models/alchemy/essence_spree_product_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe Alchemy::EssenceSpreeProduct, type: :model do
   end
 
   describe "ingredient=" do
+    context "when String value is empty" do
+      let(:value) { "" }
+
+      before do
+        essence.ingredient = value
+      end
+
+      it "sets spree_product_id to nil" do
+        expect(essence.spree_product_id).to eq(nil)
+      end
+    end
+
     context "when String value is only a number" do
       let(:value) { "101" }
 

--- a/spec/models/alchemy/essence_spree_taxon_spec.rb
+++ b/spec/models/alchemy/essence_spree_taxon_spec.rb
@@ -1,45 +1,45 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require 'alchemy/test_support/essence_shared_examples'
+require "rails_helper"
+require "alchemy/test_support/essence_shared_examples"
 
-require_dependency 'alchemy/site'
+require_dependency "alchemy/site"
 
 RSpec.describe Alchemy::EssenceSpreeTaxon, type: :model do
   let(:taxon) { build_stubbed(:taxon) }
   let(:essence) { described_class.new(taxon: taxon) }
 
-  it_behaves_like 'an essence' do
+  it_behaves_like "an essence" do
     let(:ingredient_value) { taxon }
   end
 
-  describe 'ingredient=' do
-    context 'when String value is only a number' do
-      let(:value) { '101' }
+  describe "ingredient=" do
+    context "when String value is only a number" do
+      let(:value) { "101" }
 
       before do
         essence.ingredient = value
       end
 
-      it 'sets taxon_id with that id' do
+      it "sets taxon_id with that id" do
         expect(essence.taxon_id).to eq(101)
       end
     end
 
-    context 'when value is an Spree Variant' do
+    context "when value is an Spree Variant" do
       let(:value) { taxon }
 
       before do
         essence.ingredient = value
       end
 
-      it 'sets taxon to that taxon' do
+      it "sets taxon to that taxon" do
         expect(essence.taxon).to eq(taxon)
       end
     end
 
-    context 'when value is not only a number' do
-      let(:value) { 'taxon1' }
+    context "when value is not only a number" do
+      let(:value) { "taxon1" }
 
       it do
         expect {
@@ -49,10 +49,10 @@ RSpec.describe Alchemy::EssenceSpreeTaxon, type: :model do
     end
   end
 
-  describe '#preview_text' do
+  describe "#preview_text" do
     subject { essence.preview_text(nil) }
 
-    it 'returns the taxons name' do
+    it "returns the taxons name" do
       is_expected.to eq(taxon.name)
     end
   end

--- a/spec/models/alchemy/essence_spree_taxon_spec.rb
+++ b/spec/models/alchemy/essence_spree_taxon_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe Alchemy::EssenceSpreeTaxon, type: :model do
   end
 
   describe "ingredient=" do
+    context "when String is empty" do
+      let(:value) { "" }
+
+      before do
+        essence.ingredient = value
+      end
+
+      it "sets taxon_id to nil" do
+        expect(essence.taxon_id).to eq(nil)
+      end
+    end
+
     context "when String value is only a number" do
       let(:value) { "101" }
 

--- a/spec/models/alchemy/essence_spree_variant_spec.rb
+++ b/spec/models/alchemy/essence_spree_variant_spec.rb
@@ -1,45 +1,45 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require 'alchemy/test_support/essence_shared_examples'
+require "rails_helper"
+require "alchemy/test_support/essence_shared_examples"
 
-require_dependency 'alchemy/site'
+require_dependency "alchemy/site"
 
 RSpec.describe Alchemy::EssenceSpreeVariant, type: :model do
   let(:variant) { build(:variant) }
   let(:essence) { described_class.new(variant: variant) }
 
-  it_behaves_like 'an essence' do
+  it_behaves_like "an essence" do
     let(:ingredient_value) { variant }
   end
 
-  describe 'ingredient=' do
-    context 'when String value is only a number' do
-      let(:value) { '101' }
+  describe "ingredient=" do
+    context "when String value is only a number" do
+      let(:value) { "101" }
 
       before do
         essence.ingredient = value
       end
 
-      it 'sets variant_id with that id' do
+      it "sets variant_id with that id" do
         expect(essence.variant_id).to eq(101)
       end
     end
 
-    context 'when value is an Spree Variant' do
+    context "when value is an Spree Variant" do
       let(:value) { variant }
 
       before do
         essence.ingredient = value
       end
 
-      it 'sets variant to that variant' do
+      it "sets variant to that variant" do
         expect(essence.variant).to eq(variant)
       end
     end
 
-    context 'when value is not only a number' do
-      let(:value) { 'variant1' }
+    context "when value is not only a number" do
+      let(:value) { "variant1" }
 
       it do
         expect {
@@ -49,10 +49,10 @@ RSpec.describe Alchemy::EssenceSpreeVariant, type: :model do
     end
   end
 
-  describe '#preview_text' do
+  describe "#preview_text" do
     subject { essence.preview_text(nil) }
 
-    it 'returns the variants name' do
+    it "returns the variants name" do
       is_expected.to eq(variant.descriptive_name)
     end
   end

--- a/spec/models/alchemy/essence_spree_variant_spec.rb
+++ b/spec/models/alchemy/essence_spree_variant_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe Alchemy::EssenceSpreeVariant, type: :model do
   end
 
   describe "ingredient=" do
+    context "when String value is empty" do
+      let(:value) { "" }
+
+      before do
+        essence.ingredient = value
+      end
+
+      it "sets variant_id to nil" do
+        expect(essence.variant_id).to eq(nil)
+      end
+    end
+
     context "when String value is only a number" do
       let(:value) { "101" }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,10 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../dummy/config/environment', __FILE__)
+require "spec_helper"
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../dummy/config/environment", __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
-require 'rspec/rails'
+require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -22,16 +22,16 @@ require 'rspec/rails'
 #
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
-require 'capybara/rspec'
-require 'capybara-screenshot/rspec'
-require 'factory_bot'
-require 'ffaker'
+require "capybara/rspec"
+require "capybara-screenshot/rspec"
+require "factory_bot"
+require "ffaker"
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 # ActiveRecord::Migration.maintain_test_schema!
 
-require 'shoulda-matchers'
+require "shoulda-matchers"
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :rspec
@@ -39,15 +39,15 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
-require 'spree/testing_support/factories'
+require "spree/testing_support/factories"
 
 if Alchemy.gem_version >= Gem::Version.new("5.2.0")
-  require 'alchemy/test_support'
+  require "alchemy/test_support"
 
   FactoryBot.definition_file_paths.concat(Alchemy::TestSupport.factory_paths)
   FactoryBot.reload
 else
-  require 'alchemy/test_support/factories'
+  require "alchemy/test_support/factories"
 end
 
 RSpec.configure do |config|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,11 +41,12 @@ end
 
 require "spree/testing_support/factories"
 
+require "alchemy/version"
 if Alchemy.gem_version >= Gem::Version.new("5.2.0")
   require "alchemy/test_support"
 
-  FactoryBot.definition_file_paths.concat(Alchemy::TestSupport.factory_paths)
-  FactoryBot.reload
+  FactoryBot.definition_file_paths.prepend(Alchemy::TestSupport.factories_path)
+  FactoryBot.find_definitions
 else
   require "alchemy/test_support/factories"
 end


### PR DESCRIPTION
If no taxon, product or variant has been chosen, saving an element errors. This allows to save an element without taxon, product or variant selected.