### PR TITLE
Register modules after app initialization

### DIFF
--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -52,4 +52,6 @@ if defined?(Spree::Auth::Engine)
   end
 end
 
-Alchemy::Modules.register_module(alchemy_module)
+Rails.application.config.after_initialize do
+  Alchemy::Modules.register_module(alchemy_module)
+end


### PR DESCRIPTION
If we do this earlier, Zeitwerk will autoload files from other engines.
This, in turn, leads to configuration from the local app's
`config/initializers` directory not being respected when loading files
from those other engines.

Case in point: When configuring Solidus' order state machine in Solidus
2.11 using `Spree::Config.state_machines.order =
  "MyOrderStateMachineModule"`, and this change is not in the gem,
Solidus' `Spree::Order` class is loaded, and the wrong module is
included.