### PR TITLE
Fix ExecJS to 2.7.0 for development and test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,10 @@ gemspec
 gem "sqlite3"
 gem "pry-rails"
 gem "sprockets", "< 4"
+
+group :development, :test do
+  # execjs 2.8 removes deprecation warnings but also breaks a number of dependent projects.
+  # in our case the culprit is `handlebars-assets`. The changes between 2.7.0 and 2.8.0 are
+  # minimal, but breaking.
+  gem "execjs", "= 2.7.0"
+end


### PR DESCRIPTION
ExecJS breaks some of Alchemy's transient dependencies, and these are
stable libraries that might not see an update soon.