### PR TITLE
Use pretty name in taxon select

### DIFF
--- a/app/assets/javascripts/alchemy/solidus/admin/taxon_select.js
+++ b/app/assets/javascripts/alchemy/solidus/admin/taxon_select.js
@@ -18,7 +18,7 @@ $.fn.alchemyTaxonSelect = function(options) {
           results: data.taxons.map(function(taxon) {
             return {
               id: taxon.id,
-              text: taxon.name
+              text: taxon.pretty_name
             }
           }),
           more: page * data.per_page < data.total_count

--- a/app/views/alchemy/essences/_essence_spree_taxon_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_spree_taxon_editor.html.erb
@@ -19,7 +19,7 @@
     <% if content.essence.taxon %>
     initialSelection: {
       id: <%= content.essence.taxon_id %>,
-      text: "<%= content.essence.taxon.name %>"
+      text: "<%= content.essence.taxon.pretty_name %>"
     }
     <% end %>
   })


### PR DESCRIPTION
When using multiple taxonomies, "pretty_name" will show you where the
taxon is nested. This is extremely useful, let's use it.

It looks like this: 
![grafik](https://user-images.githubusercontent.com/703401/122797525-d93a5f80-d2bf-11eb-8cd1-5942cfb610c6.png)
