### PR TITLE
Fix DOM ids of ingredient editors

### DIFF
--- a/app/views/alchemy/ingredients/_spree_product_editor.html.erb
+++ b/app/views/alchemy/ingredients/_spree_product_editor.html.erb
@@ -5,6 +5,7 @@
     <%= ingredient_label(spree_product_editor, :product_id) %>
     <%= f.text_field :product_id,
       value: spree_product_editor.product&.id,
+      id: spree_product_editor.form_field_id(:product_id),
       class: 'alchemy_selectbox full_width' %>
   <% end %>
 <% end %>

--- a/app/views/alchemy/ingredients/_spree_taxon_editor.html.erb
+++ b/app/views/alchemy/ingredients/_spree_taxon_editor.html.erb
@@ -5,6 +5,7 @@
     <%= ingredient_label(spree_taxon_editor, :taxon_id) %>
     <%= f.text_field :taxon_id,
       value: spree_taxon_editor.taxon&.id,
+      id: spree_taxon_editor.form_field_id(:taxon_id),
       class: 'alchemy_selectbox full_width' %>
   <% end %>
 <% end %>

--- a/app/views/alchemy/ingredients/_spree_variant_editor.html.erb
+++ b/app/views/alchemy/ingredients/_spree_variant_editor.html.erb
@@ -5,6 +5,7 @@
     <%= ingredient_label(spree_variant_editor, :variant_id) %>
     <%= f.text_field :variant_id,
       value: spree_variant_editor.variant&.id,
+      id: spree_variant_editor.form_field_id(:variant_id),
       class: 'alchemy_selectbox full_width' %>
   <% end %>
 <% end %>


### PR DESCRIPTION
We need to have unique DOM ids for ingredient editors

Follows https://github.com/AlchemyCMS/alchemy_cms/pull/2167