### PR TITLE
Remove deprecated X-Spree-Token 

### DIFF
--- a/alchemy-solidus.gemspec
+++ b/alchemy-solidus.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |gem|
   gem.version       = Alchemy::Solidus::VERSION
 
   gem.add_dependency('alchemy_cms', ['>= 5.0.0', '< 6.1'])
-  gem.add_dependency('solidus_core', ['>= 2.10.0', '< 3.0'])
-  gem.add_dependency('solidus_backend', ['>= 2.10.0', '< 3.0'])
+  gem.add_dependency('solidus_core', ['>= 2.10.0', '< 4.0'])
+  gem.add_dependency('solidus_backend', ['>= 2.10.0', '< 4.0'])
   gem.add_dependency('solidus_support', ['>= 0.1.1'])
   gem.add_dependency('deface', ['~> 1.0'])
 

--- a/alchemy-solidus.gemspec
+++ b/alchemy-solidus.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |gem|
   gem.version       = Alchemy::Solidus::VERSION
 
   gem.add_dependency('alchemy_cms', ['>= 5.0.0', '< 6.1'])
-  gem.add_dependency('solidus_core', ['>= 2.10.0', '< 4.0'])
-  gem.add_dependency('solidus_backend', ['>= 2.10.0', '< 4.0'])
+  gem.add_dependency('solidus_core', ['>= 2.10.0', '< 3.0'])
+  gem.add_dependency('solidus_backend', ['>= 2.10.0', '< 3.0'])
   gem.add_dependency('solidus_support', ['>= 0.1.1'])
   gem.add_dependency('deface', ['~> 1.0'])
 

--- a/app/assets/javascripts/alchemy/solidus/admin/select2_config.js
+++ b/app/assets/javascripts/alchemy/solidus/admin/select2_config.js
@@ -3,7 +3,7 @@ Alchemy.Solidus = Alchemy.Solidus || {}
 
 Alchemy.Solidus.getSelect2Config = function(options) {
   var headers = {
-    'X-Spree-Token': options.apiToken
+    'Authorization': 'Bearer ' + options.apiToken
   }
 
   return {


### PR DESCRIPTION
The old token got deprecated and then removed. It looks like this was deprecated as of v2.10, but not removed until v3.0. I'm not sure if it's better or worse to set both headers.