### PR TITLE
Test Alchemy 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,12 @@
 name: CI
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+on: [push, pull_request]
 
 jobs:
   Rspec:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
           - 2.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,8 @@ jobs:
         ruby-version:
           - 2.7
         alchemy:
-          - 5.0-stable
-          - 5.1-stable
-          - 5.2-stable
+          - 5.3-stable
+          - 6.0-stable
           - main
         solidus:
           - v2.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
           - 6.0-stable
           - main
         solidus:
-          - v2.10
           - v2.11
           - v3.0
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
         solidus:
           - v2.11
           - v3.0
+        exclude:
+          - alchemy: "5.3-stable"
+            solidus: "v3.0"
+            ruby-version: 2.7
     env:
       ALCHEMY_BRANCH: ${{ matrix.alchemy }}
       SOLIDUS_BRANCH: ${{ matrix.solidus }}

--- a/README.md
+++ b/README.md
@@ -13,15 +13,19 @@ This is a [AlchemyCMS](https://alchemy-cms.com) and [Solidus](https://solidus.io
 
 ### Solidus
 
-This version runs with Solidus 2.6 and above.
+This version runs with Solidus v2.11 and v3.0.
 
+- For a Solidus < 2.11 compatible version please use the `3.1-stable` branch or `3.3.0` gem version.
 - For a Solidus < 2.6 compatible version please use the `2.3-stable` branch or `2.3.2` gem version.
 - For a Solidus 1.x compatible version please use the `1.0-stable` branch or `1.1.0` gem version.
 
+> **NOTE:** If you are using Solidus v3.0 with Alchemy v5.3, make sure to also use Rails v6.0 and the legacy image attachment adapter (paperclip) and not the active storage adapter, since this needs Rails >= 6.1 and Alchemy v5.3 is not Rails 6.1 compatible. You need Alchemy v6.0 for Rails >= 6.1.
+
 ### Alchemy
 
-This version runs with Alchemy 4.1 and above.
+This version runs with Alchemy v5.x and v6.0.
 
+- For a Alchemy 4.x compatible version please use the `3.1-stable` branch or `3.3.0` gem version.
 - For a Alchemy 4.0 compatible version please use the `2.3-stable` branch or `2.3.2` gem version.
 - For a Alchemy 3.x compatible version please use the `1.0-stable` branch or `1.1.0` gem version.
 

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ task :test_setup do
       bin/rake db:environment:set db:drop && \
       bin/rake gutentag:install:migrations && \
       bin/rails g gutentag:migration_versions && \
-      bin/rails g spree:install --force --auto-accept --no-seed --no-sample && \
+      bin/rails g #{ENV["SOLIDUS_BRANCH"].match?(/^2.+/) ? "spree" : "solidus"}:install --force --auto-accept --no-seed --no-sample && \
       bin/rails g alchemy:solidus:install --auto-accept --force
     SETUP
     exit($?.exitstatus) unless $?.success?

--- a/alchemy-solidus.gemspec
+++ b/alchemy-solidus.gemspec
@@ -1,29 +1,29 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path('../lib/alchemy/solidus/version', __FILE__)
+require File.expand_path("../lib/alchemy/solidus/version", __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Thomas von Deyen"]
-  gem.email         = ["thomas@vondeyen.com"]
-  gem.description   = %q{A AlchemyCMS and Solidus integration}
-  gem.summary       = %q{The World's Most Flexible E-Commerce Platform meets The World's Most Flexible Content Management System!}
-  gem.homepage      = "https://github.com/AlchemyCMS/alchemy-solidus"
-  gem.license       = 'BSD New'
-  gem.files         = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
-  gem.name          = "alchemy-solidus"
+  gem.authors = ["Thomas von Deyen"]
+  gem.email = ["thomas@vondeyen.com"]
+  gem.description = %q{A AlchemyCMS and Solidus integration}
+  gem.summary = %q{The World's Most Flexible E-Commerce Platform meets The World's Most Flexible Content Management System!}
+  gem.homepage = "https://github.com/AlchemyCMS/alchemy-solidus"
+  gem.license = "BSD New"
+  gem.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
+  gem.name = "alchemy-solidus"
   gem.require_paths = ["lib"]
-  gem.version       = Alchemy::Solidus::VERSION
+  gem.version = Alchemy::Solidus::VERSION
 
-  gem.add_dependency('alchemy_cms', ['>= 5.0.0', '< 6.1'])
-  gem.add_dependency('solidus_core', ['>= 2.10.0', '< 4.0'])
-  gem.add_dependency('solidus_backend', ['>= 2.10.0', '< 4.0'])
-  gem.add_dependency('solidus_support', ['>= 0.1.1'])
-  gem.add_dependency('deface', ['~> 1.0'])
+  gem.add_dependency("alchemy_cms", [">= 5.0.0", "< 6.1"])
+  gem.add_dependency("solidus_core", [">= 2.10.0", "< 4.0"])
+  gem.add_dependency("solidus_backend", [">= 2.10.0", "< 4.0"])
+  gem.add_dependency("solidus_support", [">= 0.1.1"])
+  gem.add_dependency("deface", ["~> 1.0"])
 
-  gem.add_development_dependency('rspec-rails', ['~> 3.7'])
-  gem.add_development_dependency('shoulda-matchers', ['~> 4.0'])
-  gem.add_development_dependency('capybara', ['~> 2.15'])
-  gem.add_development_dependency('capybara-screenshot', ['~> 1.0'])
-  gem.add_development_dependency('factory_bot', ['~> 4.8'])
-  gem.add_development_dependency('ffaker', ['~> 2.7'])
-  gem.add_development_dependency('github_changelog_generator')
+  gem.add_development_dependency("rspec-rails", ["~> 5.0"])
+  gem.add_development_dependency("shoulda-matchers", ["~> 4.0"])
+  gem.add_development_dependency("capybara", ["~> 2.15"])
+  gem.add_development_dependency("capybara-screenshot", ["~> 1.0"])
+  gem.add_development_dependency("factory_bot", ["~> 4.8"])
+  gem.add_development_dependency("ffaker", ["~> 2.7"])
+  gem.add_development_dependency("github_changelog_generator")
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,15 +41,9 @@ end
 
 require "spree/testing_support/factories"
 
-require "alchemy/version"
-if Alchemy.gem_version >= Gem::Version.new("5.2.0")
-  require "alchemy/test_support"
-
-  FactoryBot.definition_file_paths.prepend(Alchemy::TestSupport.factories_path)
-  FactoryBot.find_definitions
-else
-  require "alchemy/test_support/factories"
-end
+require "alchemy/test_support"
+FactoryBot.definition_file_paths.append(Alchemy::TestSupport.factories_path)
+FactoryBot.reload
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,12 +39,8 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
-if Spree.solidus_gem_version >= Gem::Version.new("2.11.0")
-  require "spree/testing_support/factory_bot"
-  Spree::TestingSupport::FactoryBot.add_paths_and_load!
-else
-  require "spree/testing_support/factories"
-end
+require "spree/testing_support/factory_bot"
+Spree::TestingSupport::FactoryBot.add_paths_and_load!
 
 require "alchemy/test_support"
 FactoryBot.definition_file_paths.append(Alchemy::TestSupport.factories_path)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,7 +39,12 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
-require "spree/testing_support/factories"
+if Spree.solidus_gem_version >= Gem::Version.new("2.11.0")
+  require "spree/testing_support/factory_bot"
+  Spree::TestingSupport::FactoryBot.add_paths_and_load!
+else
+  require "spree/testing_support/factories"
+end
 
 require "alchemy/test_support"
 FactoryBot.definition_file_paths.append(Alchemy::TestSupport.factories_path)


### PR DESCRIPTION
Adds Alchemy v6.0 to test matrix.

> **NOTE:** If you are using Solidus v3.0 with Alchemy v5.3, make sure to also use Rails v6.0 and the legacy image attachment adapter (paperclip) and not the active storage adapter, since this needs Rails >= 6.1 and Alchemy v5.3 is not Rails 6.1 compatible. You need Alchemy v6.0 for Rails >= 6.1.
