### PR TITLE
Add #preload_relations to SpreeProduct ingredient

### DIFF
--- a/app/models/alchemy/ingredients/spree_product.rb
+++ b/app/models/alchemy/ingredients/spree_product.rb
@@ -5,6 +5,10 @@ module Alchemy
     class SpreeProduct < Alchemy::Ingredient
       related_object_alias :product, class_name: "Spree::Product"
 
+      def preload_relations
+        [{ taxons: :taxonomy }, { master: :images }]
+      end
+
       def preview_text(maxlength)
         return unless product
 

--- a/spec/models/alchemy/ingredients/spree_product_spec.rb
+++ b/spec/models/alchemy/ingredients/spree_product_spec.rb
@@ -39,5 +39,11 @@ if Alchemy.gem_version >= Gem::Version.new("6.0.0.b1")
         it { is_expected.to be_nil }
       end
     end
+
+    describe "#preload_relations" do
+      subject { ingredient.preload_relations }
+
+      it { is_expected.to eq([{ taxons: :taxonomy }, { master: :images }]) }
+    end
   end
 end


### PR DESCRIPTION
The SpreeProduct ingredient frequently needs to display not only the product name, but also some images and possibly a taxon. Let's allow preloading these!