### PR TITLE
Add Solidus Alchemy menu items in initializer

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -2,68 +2,67 @@ if defined?(Alchemy::Devise::Engine)
   Spree.user_class = "Alchemy::User"
 end
 
-Rails.application.config.after_initialize do
-  Spree::Backend::Config.configure do |config|
-    alchemy_menu_item = if Spree.solidus_gem_version >= Gem::Version.new("4.2.0")
-      config.class::MenuItem.new(
-        label: :cms,
-        icon: "copy",
-        condition: -> { can?(:index, :alchemy_admin_dashboard) },
-        url: -> { Alchemy::Engine.routes.url_helpers.admin_dashboard_path },
-        children: [
-          config.class::MenuItem.new(
-            label: :pages,
-            condition: -> { can?(:index, :alchemy_admin_pages) },
-            url: -> { Alchemy::Engine.routes.url_helpers.admin_pages_path },
-            match_path: "/pages"
-          ),
-          config.class::MenuItem.new(
-            label: :languages,
-            condition: -> { can?(:index, :alchemy_admin_sites) },
-            url: -> { Alchemy::Engine.routes.url_helpers.admin_sites_path },
-            match_path: "/languages"
-          ),
-          (if defined?(Alchemy::Devise::Engine)
-             config.class::MenuItem.new(
-               label: :users,
-               condition: -> { can?(:index, :alchemy_admin_users) },
-               url: -> { Alchemy::Engine.routes.url_helpers.admin_users_path },
-               match_path: "/users"
-             )
-           end),
-          config.class::MenuItem.new(
-            label: :tags,
-            condition: -> { can?(:index, :alchemy_admin_tags) },
-            url: -> { Alchemy::Engine.routes.url_helpers.admin_tags_path }
-          ),
-          config.class::MenuItem.new(
-            label: :pictures,
-            condition: -> { can?(:index, :alchemy_admin_pictures) },
-            url: -> { Alchemy::Engine.routes.url_helpers.admin_pictures_path }
-          ),
-          config.class::MenuItem.new(
-            label: :attachments,
-            condition: -> { can?(:index, :alchemy_admin_attachments) },
-            url: -> { Alchemy::Engine.routes.url_helpers.admin_attachments_path }
-          )
-        ].compact
-      )
-    else
-      config.class::MenuItem.new(
-        [:pages, :sites, :languages, :tags, :users, :pictures, :attachments],
-        "copy",
-        label: :cms,
-        condition: -> { can?(:index, :alchemy_admin_dashboard) },
-        partial: "spree/admin/shared/alchemy_sub_menu",
-        url: "/admin/pages",
-        match_path: "/pages"
-      )
-    end
+Spree::Backend::Config.configure do |config|
+  alchemy_menu_item = if Spree.solidus_gem_version >= Gem::Version.new("4.2.0")
+    config.class::MenuItem.new(
+      label: :cms,
+      icon: "copy",
+      condition: -> { can?(:index, :alchemy_admin_dashboard) },
+      url: -> { Alchemy::Engine.routes.url_helpers.admin_dashboard_path },
+      children: [
+        config.class::MenuItem.new(
+          label: :pages,
+          condition: -> { can?(:index, :alchemy_admin_pages) },
+          url: -> { Alchemy::Engine.routes.url_helpers.admin_pages_path },
+          match_path: "/pages"
+        ),
+        config.class::MenuItem.new(
+          label: :languages,
+          condition: -> { can?(:index, :alchemy_admin_sites) },
+          url: -> { Alchemy::Engine.routes.url_helpers.admin_sites_path },
+          match_path: "/languages"
+        ),
+        (if defined?(Alchemy::Devise::Engine)
+            config.class::MenuItem.new(
+              label: :users,
+              condition: -> { can?(:index, :alchemy_admin_users) },
+              url: -> { Alchemy::Engine.routes.url_helpers.admin_users_path },
+              match_path: "/users"
+            )
+          end),
+        config.class::MenuItem.new(
+          label: :tags,
+          condition: -> { can?(:index, :alchemy_admin_tags) },
+          url: -> { Alchemy::Engine.routes.url_helpers.admin_tags_path }
+        ),
+        config.class::MenuItem.new(
+          label: :pictures,
+          condition: -> { can?(:index, :alchemy_admin_pictures) },
+          url: -> { Alchemy::Engine.routes.url_helpers.admin_pictures_path }
+        ),
+        config.class::MenuItem.new(
+          label: :attachments,
+          condition: -> { can?(:index, :alchemy_admin_attachments) },
+          url: -> { Alchemy::Engine.routes.url_helpers.admin_attachments_path }
+        )
+      ].compact
+    )
+  else
+    config.class::MenuItem.new(
+      [:pages, :sites, :languages, :tags, :users, :pictures, :attachments],
+      "copy",
+      label: :cms,
+      condition: -> { can?(:index, :alchemy_admin_dashboard) },
+      partial: "spree/admin/shared/alchemy_sub_menu",
+      url: "/admin/pages",
+      match_path: "/pages"
+    )
+  end
+  config.menu_items << alchemy_menu_item
+end
 
-    if config.menu_items.any? { |menu_item| menu_item.label == :cms }
-      Alchemy::Deprecation.warn("You configured the Alchemy menu items in your app's initializers. We can do that for you now! Please remove the menu item with the label `:cms`.")
-    else
-      config.menu_items << alchemy_menu_item
-    end
+Rails.application.config.after_initialize do
+  if Spree::Backend::Config.menu_items.many? { |menu_item| menu_item.label == :cms }
+    Alchemy::Deprecation.warn("You configured the Alchemy menu items in your app's initializers. We can do that for you now! Please remove the menu item with the label `:cms`.")
   end
 end

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -1,3 +1,69 @@
 if defined?(Alchemy::Devise::Engine)
   Spree.user_class = "Alchemy::User"
 end
+
+Rails.application.config.after_initialize do
+  Spree::Backend::Config.configure do |config|
+    alchemy_menu_item = if Spree.solidus_gem_version >= Gem::Version.new("4.2.0")
+      config.class::MenuItem.new(
+        label: :cms,
+        icon: "copy",
+        condition: -> { can?(:index, :alchemy_admin_dashboard) },
+        url: -> { Alchemy::Engine.routes.url_helpers.admin_dashboard_path },
+        children: [
+          config.class::MenuItem.new(
+            label: :pages,
+            condition: -> { can?(:index, :alchemy_admin_pages) },
+            url: -> { Alchemy::Engine.routes.url_helpers.admin_pages_path },
+            match_path: "/pages"
+          ),
+          config.class::MenuItem.new(
+            label: :languages,
+            condition: -> { can?(:index, :alchemy_admin_sites) },
+            url: -> { Alchemy::Engine.routes.url_helpers.admin_sites_path },
+            match_path: "/languages"
+          ),
+          (if defined?(Alchemy::Devise::Engine)
+             config.class::MenuItem.new(
+               label: :users,
+               condition: -> { can?(:index, :alchemy_admin_users) },
+               url: -> { Alchemy::Engine.routes.url_helpers.admin_users_path },
+               match_path: "/users"
+             )
+           end),
+          config.class::MenuItem.new(
+            label: :tags,
+            condition: -> { can?(:index, :alchemy_admin_tags) },
+            url: -> { Alchemy::Engine.routes.url_helpers.admin_tags_path }
+          ),
+          config.class::MenuItem.new(
+            label: :pictures,
+            condition: -> { can?(:index, :alchemy_admin_pictures) },
+            url: -> { Alchemy::Engine.routes.url_helpers.admin_pictures_path }
+          ),
+          config.class::MenuItem.new(
+            label: :attachments,
+            condition: -> { can?(:index, :alchemy_admin_attachments) },
+            url: -> { Alchemy::Engine.routes.url_helpers.admin_attachments_path }
+          )
+        ].compact
+      )
+    else
+      config.class::MenuItem.new(
+        [:pages, :sites, :languages, :tags, :users, :pictures, :attachments],
+        "copy",
+        label: :cms,
+        condition: -> { can?(:index, :alchemy_admin_dashboard) },
+        partial: "spree/admin/shared/alchemy_sub_menu",
+        url: "/admin/pages",
+        match_path: "/pages"
+      )
+    end
+
+    if config.menu_items.any? { |menu_item| menu_item.label == :cms }
+      Alchemy::Deprecation.warn("You configured the Alchemy menu items in your app's initializers. We can do that for you now! Please remove the menu item with the label `:cms`.")
+    else
+      config.menu_items << alchemy_menu_item
+    end
+  end
+end

--- a/lib/generators/alchemy/solidus/install/install_generator.rb
+++ b/lib/generators/alchemy/solidus/install/install_generator.rb
@@ -90,27 +90,6 @@ module Alchemy
         end
       end
 
-      def inject_admin_tab
-        inject_into_file "config/initializers/spree.rb",
-                         {
-                           after:
-                             "Spree::Backend::Config.configure do |config|\n"
-                         } do
-          <<~ADMIN_TAB
-            \  # AlchemyCMS admin tabs
-            \  config.menu_items << config.class::MenuItem.new(
-            \    [:pages, :sites, :languages, :tags, :users, :pictures, :attachments],
-            \    'copy',
-            \    label: :cms,
-            \    condition: -> { can?(:index, :alchemy_admin_dashboard) },
-            \    partial: 'spree/admin/shared/alchemy_sub_menu',
-            \    url: '/admin/pages',
-            \    match_path: '/pages'
-            \  )
-          ADMIN_TAB
-        end
-      end
-
       def create_admin_user
         if alchemy_devise_present? && !options[:skip_alchemy_user_generator] &&
              Alchemy::User.count.zero?


### PR DESCRIPTION
This adds the menu items for Alchemy in an `after_initialize` hook rather than modifying the `spree.rb` initializer. The advantage here is that we can support both the new MenuItem API from Solidus 4.2+ as well as the old one. For people who have either not wrapped their in-app initializer in a `config.after_initialize` hook, we will also add a nice deprecation warning if they already have the Alchemy menu item in the list of menu items. For people who have wrapped their backend configuration in `after_initialize`, there is no hook we can hook into after that. They will see a double menu entry, and figure out to delete their own.