### PR TITLE
Fixes for Solidus 4.2 menu items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-solidus_version = ENV.fetch("SOLIDUS_VERSION", "4.1")
+solidus_version = ENV.fetch("SOLIDUS_VERSION", "4.2")
 gem "solidus_core", "~> #{solidus_version}.0"
 gem "solidus_backend", "~> #{solidus_version}.0"
 if Gem::Version.new(solidus_version) >= Gem::Version.new("4.0")

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ require "active_support/core_ext/string"
 
 desc "Setup test app"
 task :test_setup do
-  solidus_version = ENV.fetch("SOLIDUS_VERSION", "4.0")
+  solidus_version = ENV.fetch("SOLIDUS_VERSION", "4.2")
   solidus_32_install_options =
     "--payment-method none --frontend none --no-with-authentication"
   solidus_33_install_options =

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -2,66 +2,69 @@ if defined?(Alchemy::Devise::Engine)
   Spree.user_class = "Alchemy::User"
 end
 
-Spree::Backend::Config.configure do |config|
-  alchemy_menu_item = if Spree.solidus_gem_version >= Gem::Version.new("4.2.0")
-    config.class::MenuItem.new(
-      label: :cms,
-      icon: "copy",
-      condition: -> { can?(:index, :alchemy_admin_dashboard) },
-      url: -> { Alchemy::Engine.routes.url_helpers.admin_dashboard_path },
-      children: [
-        config.class::MenuItem.new(
-          label: :pages,
-          condition: -> { can?(:index, :alchemy_admin_pages) },
-          url: -> { Alchemy::Engine.routes.url_helpers.admin_pages_path },
-          match_path: "/pages"
-        ),
-        config.class::MenuItem.new(
-          label: :languages,
-          condition: -> { can?(:index, :alchemy_admin_sites) },
-          url: -> { Alchemy::Engine.routes.url_helpers.admin_sites_path },
-          match_path: "/languages"
-        ),
-        (if defined?(Alchemy::Devise::Engine)
-            config.class::MenuItem.new(
-              label: :users,
-              condition: -> { can?(:index, :alchemy_admin_users) },
-              url: -> { Alchemy::Engine.routes.url_helpers.admin_users_path },
-              match_path: "/users"
-            )
-          end),
-        config.class::MenuItem.new(
-          label: :tags,
-          condition: -> { can?(:index, :alchemy_admin_tags) },
-          url: -> { Alchemy::Engine.routes.url_helpers.admin_tags_path }
-        ),
-        config.class::MenuItem.new(
-          label: :pictures,
-          condition: -> { can?(:index, :alchemy_admin_pictures) },
-          url: -> { Alchemy::Engine.routes.url_helpers.admin_pictures_path }
-        ),
-        config.class::MenuItem.new(
-          label: :attachments,
-          condition: -> { can?(:index, :alchemy_admin_attachments) },
-          url: -> { Alchemy::Engine.routes.url_helpers.admin_attachments_path }
-        )
-      ].compact
-    )
-  else
-    config.class::MenuItem.new(
-      [:pages, :sites, :languages, :tags, :users, :pictures, :attachments],
-      "copy",
-      label: :cms,
-      condition: -> { can?(:index, :alchemy_admin_dashboard) },
-      partial: "spree/admin/shared/alchemy_sub_menu",
-      url: "/admin/pages",
-      match_path: "/pages"
-    )
-  end
-  config.menu_items << alchemy_menu_item
-end
-
 Rails.application.config.after_initialize do
+  Spree::Backend::Config.configure do |config|
+    alchemy_menu_item = if Spree.solidus_gem_version >= Gem::Version.new("4.2.0")
+      config.class::MenuItem.new(
+        label: :cms,
+        icon: config.admin_updated_navbar ? "ri-pages-line" : "copy",
+        condition: -> { can?(:index, :alchemy_admin_dashboard) },
+        url: -> { Alchemy::Engine.routes.url_helpers.admin_dashboard_path },
+        children: [
+          config.class::MenuItem.new(
+            label: :pages,
+            condition: -> { can?(:index, :alchemy_admin_pages) },
+            url: -> { Alchemy::Engine.routes.url_helpers.admin_pages_path },
+            match_path: "/pages"
+          ),
+          config.class::MenuItem.new(
+            label: :languages,
+            condition: -> { can?(:index, :alchemy_admin_sites) },
+            url: -> { Alchemy::Engine.routes.url_helpers.admin_sites_path },
+            match_path: "/languages"
+          ),
+          (if defined?(Alchemy::Devise::Engine)
+              config.class::MenuItem.new(
+                label: :users,
+                condition: -> { can?(:index, :alchemy_admin_users) },
+                url: -> { Alchemy::Engine.routes.url_helpers.admin_users_path },
+                match_path: "/users"
+              )
+            end),
+          config.class::MenuItem.new(
+            label: :tags,
+            condition: -> { can?(:index, :alchemy_admin_tags) },
+            url: -> { Alchemy::Engine.routes.url_helpers.admin_tags_path }
+          ),
+          config.class::MenuItem.new(
+            label: :pictures,
+            condition: -> { can?(:index, :alchemy_admin_pictures) },
+            url: -> { Alchemy::Engine.routes.url_helpers.admin_pictures_path }
+          ),
+          config.class::MenuItem.new(
+            label: :attachments,
+            condition: -> { can?(:index, :alchemy_admin_attachments) },
+            url: -> { Alchemy::Engine.routes.url_helpers.admin_attachments_path }
+          )
+        ].compact
+      )
+    else
+      config.class::MenuItem.new(
+        [:pages, :sites, :languages, :tags, :users, :pictures, :attachments],
+        "copy",
+        label: :cms,
+        condition: -> { can?(:index, :alchemy_admin_dashboard) },
+        partial: "spree/admin/shared/alchemy_sub_menu",
+        url: "/admin/pages",
+        match_path: "/pages"
+      )
+    end
+    settings = config.menu_items.detect { |item| item.label == :settings }
+    config.menu_items.index(settings).tap do |index|
+      config.menu_items.insert(index, alchemy_menu_item)
+    end
+  end
+
   if Spree::Backend::Config.menu_items.many? { |menu_item| menu_item.label == :cms }
     Alchemy::Deprecation.warn("You configured the Alchemy menu items in your app's initializers. We can do that for you now! Please remove the menu item with the label `:cms`.")
   end

--- a/lib/generators/alchemy/solidus/install/install_generator.rb
+++ b/lib/generators/alchemy/solidus/install/install_generator.rb
@@ -1,12 +1,5 @@
 require "rails/generators"
-require "alchemy/version"
-
-if Alchemy.gem_version >= Gem::Version.new("5.0.0.a")
-  require "generators/alchemy/install/install_generator"
-else
-  require "rails/generators/alchemy/install/install_generator"
-end
-
+require "generators/alchemy/install/install_generator"
 require "generators/spree/custom_user/custom_user_generator"
 require "solidus_support"
 


### PR DESCRIPTION
Solidus 4.2 has changed how to setup menu items and introduced a new optional admin navbar.

This updates the menu item config to

1. Run the config in after initialize, so we make sure the menu has been setup by the main app correctly
2. We use the new remix icons if the new admin menu is used.
3. We add our menu tab above the settings icon.

This solves an issue with new icons showing up in the old admin navigation due to load order issues.

### Before

![admin tabs before](https://github.com/AlchemyCMS/alchemy-solidus/assets/42868/34c14786-0d6b-47c3-a5b2-1a6014328eb5)

### After

![admin tabs after](https://github.com/AlchemyCMS/alchemy-solidus/assets/42868/e126e8b4-5f9a-45e5-b761-a1bcd27da241)
