### PR TITLE
Update product link selection for Alchemy 7.1

### DIFF
--- a/app/views/alchemy/admin/pages/_product_link_script.html.erb
+++ b/app/views/alchemy/admin/pages/_product_link_script.html.erb
@@ -1,5 +1,7 @@
 <script>
-  $("#overlay_tabs").on("SelectLinkTab.Alchemy", function(event, data) {
+  var $tabs = $("#overlay_tabs")
+
+  $tabs.on("SelectLinkTab.Alchemy", function(event, data) {
     $("#product_link").select2("val", data.link.attr("href"))
   })
   $("#product_link").alchemyProductSelect({
@@ -31,9 +33,13 @@
             id: Spree.mountedAt() + "products/"+ product.slug,
             text: product.name
           })
-          $("#overlay_tabs").tabs("option", "active",
-            $("#overlay_tabs > div").index($("#overlay_tab_product_link"))
-          )
+          if (typeof $tabs.tabs === "function") {
+            $tabs.tabs("option", "active",
+              $("#overlay_tabs > div").index($("#overlay_tab_product_link"))
+            )
+          } else {
+            $tabs.get(0).show('overlay_tab_product_link')
+          }
         }
       })
     },


### PR DESCRIPTION
Alchemy 7.1 uses Shoelace tabs over jQuery UI tabs. 
We check if jQuery UI (Alchemy 7.0 and 6.1) is still used or already Shoelace tabs.