### PR TITLE
Use generic shop icon in menu tab

### DIFF
--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -5,9 +5,7 @@ alchemy_module = {
     controller: '/spree/admin/orders',
     action: 'index',
     name: 'Store',
-    inline_image: '<svg version="1.1" width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="vertical-align: middle">
-      <path d="M 6.687 21.839 L 17.314 21.839 L 17.314 2.162 L 6.687 2.162 Z M 19.476 24 L 4.525 24 L 4.525 0 L 19.476 0 Z M 13.89 17 C 13.307 16.662 13.078 16.287 13.05 15.313 L 13.05 8.574 C 13.05 6.554 12.05 5.814 9.911 4.794 L 8.99 6.434 L 10.111 7.074 C 10.693 7.412 10.923 7.786 10.951 8.761 L 10.951 15.5 C 10.951 17.52 11.951 18.26 14.09 19.279 L 15.01 17.64 Z" fill="currentColor"/>
-    </svg>',
+    icon: 'shopping-cart-line',
     data: { turbolinks: false },
     sub_navigation: [
       {


### PR DESCRIPTION
No user ever recognizes this icon as a Shop icon.
Also it is the old Solidus icon.
Let's use a generic icon, so it is easier to understand and maintain.

<img width="" alt="Slack - Channel: infrastructure - Candlescience 2024-03-08 16-06-53" src="https://github.com/AlchemyCMS/alchemy-solidus/assets/42868/8e1e8920-c523-4125-8dcb-80fa81186aa4">
