### PR TITLE
Allow to clear taxon, product and variant selection

### DIFF
--- a/app/assets/javascripts/alchemy/solidus/admin/select2_config.js
+++ b/app/assets/javascripts/alchemy/solidus/admin/select2_config.js
@@ -9,6 +9,7 @@ Alchemy.Solidus.getSelect2Config = function (options) {
   return {
     placeholder: options.placeholder,
     minimumInputLength: 3,
+    allowClear: true,
     initSelection:
       options.initSelection ||
       function (_$el, callback) {


### PR DESCRIPTION
One might want to clear the selected taxon, product or variant in an element.