### PR TITLE
Restrict SQLite to ~> 1.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "alchemy-devise", github: "AlchemyCMS/alchemy-devise", branch: "main"
 # Specify your gem's dependencies in alchemy-solidus.gemspec
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "~> 1.4"
 gem "pry-rails"
 gem "sprockets", "~> 4.0"
 gem "jsbundling-rails", "~> 1.1"


### PR DESCRIPTION
SQLite 2.0 has been released, and breaks all Solidus extensions. Restrict to 1.4 to prevent errors.