### PR TITLE
Add alchemy_display_name to Spree::User

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,13 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"
         alchemy:
+          - "7.2-stable"
           - "main"
         solidus:
-          - "4.0"
           - "4.1"
           - "4.2"
           - "4.3"
@@ -24,7 +23,7 @@ jobs:
       ALCHEMY_VERSION: ${{ matrix.alchemy }}
       SOLIDUS_VERSION: ${{ matrix.solidus }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/lib/alchemy/solidus/spree_user_extension.rb
+++ b/lib/alchemy/solidus/spree_user_extension.rb
@@ -5,6 +5,10 @@ module Alchemy
         klass.has_many :folded_pages, class_name: "Alchemy::FoldedPage"
       end
 
+      def alchemy_display_name
+        email
+      end
+
       def alchemy_roles
         if has_spree_role?(:admin)
           %w(admin)

--- a/spec/models/spree/user_extension_spec.rb
+++ b/spec/models/spree/user_extension_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "alchemy/solidus/spree_user_extension"
+
+RSpec.describe Alchemy::Solidus::SpreeUserExtension, type: :model do
+  let(:spree_user) do
+    Class.new(ActiveRecord::Base) do
+      def self.name
+        "Spree::User"
+      end
+
+      def has_spree_role?(_role)
+        false
+      end
+
+      include Alchemy::Solidus::SpreeUserExtension
+    end
+  end
+
+  let(:user) { spree_user.new(email: "spree@example.com") }
+
+  describe "#alchemy_roles" do
+    context "when user is an admin" do
+      it "returns an array with the admin role" do
+        allow(user).to receive(:has_spree_role?).with(:admin).and_return(true)
+        expect(user.alchemy_roles).to eq %w[admin]
+      end
+    end
+
+    context "when user is not an admin" do
+      it { expect(user.alchemy_roles).to be_empty }
+    end
+  end
+
+  describe "#alchemy_display_name" do
+    context "when user is not an admin" do
+      it "returns user's email" do
+        expect(user.alchemy_display_name).to eq "spree@example.com"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Alchemy uses this to identify users in the admin UI.

Needs https://github.com/AlchemyCMS/alchemy_cms/pull/3027