### PR TITLE
Remove navigation deep link to promotions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
         alchemy:
           - "7.2-stable"
           - "7.3-stable"
-          - "main"
         solidus:
           - "4.1"
           - "4.2"

--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -19,11 +19,6 @@ alchemy_module = {
         name: 'Products'
       },
       {
-        controller: '/spree/admin/promotions',
-        action: 'index',
-        name: 'Promotions'
-      },
-      {
         controller: '/spree/admin/stock_items',
         action: 'index',
         name: 'Stock'


### PR DESCRIPTION
In the current Solidus `main` branch, the
`Spree::Admin::PromotionsController` does not exist anymore if one only requires `solidus_core` and `solidus_backend`. It's only present if one requires the full `solidus` suite with the `solidus_legacy_promotions` gem.

There's also the new `solidus_promotions` gem, and now the path to configuring the promotion system depends on the gem being used. By the time we run this code, the promotion system configuration is probably not loaded. Given that we don't do anything with promotions in this gem, let's remove the deep link. Customers can still get at the promotions admin via the navigation in Solidus.