### PR TITLE
Allow Alchemy 8.x

### DIFF
--- a/alchemy-solidus.gemspec
+++ b/alchemy-solidus.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version = Alchemy::Solidus::VERSION
 
-  gem.add_dependency("alchemy_cms", [">= 7.2.0", "< 8"])
+  gem.add_dependency("alchemy_cms", [">= 7.2.0", "< 8.1"])
   gem.add_dependency("solidus_core", [">= 4.0.0", "< 5"])
   gem.add_dependency("solidus_backend", [">= 4.0.0", "< 5"])
   gem.add_dependency("solidus_support", [">= 0.1.1", "< 1"])


### PR DESCRIPTION
Alchemy main is now on 8.0.alpha, so we need to raise the allowed versions here.