### PR TITLE
Use branches for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
           - "7.2-stable"
           - "7.3-stable"
         solidus:
-          - "4.1"
-          - "4.2"
-          - "4.3"
-          - "4.4"
+          - "v4.1"
+          - "v4.2"
+          - "v4.3"
+          - "v4.4"
     env:
       ALCHEMY_VERSION: ${{ matrix.alchemy }}
-      SOLIDUS_VERSION: ${{ matrix.solidus }}
+      SOLIDUS_BRANCH: ${{ matrix.solidus }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           - "v4.3"
           - "v4.4"
     env:
-      ALCHEMY_VERSION: ${{ matrix.alchemy }}
+      ALCHEMY_BRANCH: ${{ matrix.alchemy }}
       SOLIDUS_BRANCH: ${{ matrix.solidus }}
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,8 @@ source "https://rubygems.org"
 solidus_version = ENV.fetch("SOLIDUS_VERSION", "4.4")
 gem "solidus_core", "~> #{solidus_version}.0"
 gem "solidus_backend", "~> #{solidus_version}.0"
-if Gem::Version.new(solidus_version) >= Gem::Version.new("4.0")
-  gem "solidus_frontend", github: "solidusio/solidus_frontend", branch: "main"
-else
-  gem "solidus_frontend", "~> #{solidus_version}.0"
-end
+gem "solidus_frontend", github: "solidusio/solidus_frontend", branch: "main"
+
 
 alchemy_version = ENV.fetch("ALCHEMY_VERSION", "main")
 if alchemy_version == "main"

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,9 @@
 source "https://rubygems.org"
 
-solidus_version = ENV.fetch("SOLIDUS_VERSION", "4.4")
-gem "solidus_core", "~> #{solidus_version}.0"
-gem "solidus_backend", "~> #{solidus_version}.0"
+solidus_branch = ENV.fetch("SOLIDUS_BRANCH", "v4.4")
+gem "solidus_core", github: "solidusio/solidus", branch: solidus_branch
+gem "solidus_backend", github: "solidusio/solidus", branch: solidus_branch
 gem "solidus_frontend", github: "solidusio/solidus_frontend", branch: "main"
-
 
 alchemy_version = ENV.fetch("ALCHEMY_VERSION", "main")
 if alchemy_version == "main"

--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,8 @@ gem "solidus_core", github: "solidusio/solidus", branch: solidus_branch
 gem "solidus_backend", github: "solidusio/solidus", branch: solidus_branch
 gem "solidus_frontend", github: "solidusio/solidus_frontend", branch: "main"
 
-alchemy_version = ENV.fetch("ALCHEMY_VERSION", "main")
-if alchemy_version == "main"
-  gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: "main"
-else
-  gem "alchemy_cms", "~> #{alchemy_version}"
-end
+alchemy_branch = ENV.fetch("ALCHEMY_BRANCH", "main")
+gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: alchemy_branch
 
 gem "alchemy-devise", github: "AlchemyCMS/alchemy-devise", branch: "main"
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,9 +14,9 @@ task default: %i[test_setup spec]
 
 desc "Setup test app"
 task :test_setup do
-  solidus_version = ENV.fetch("SOLIDUS_VERSION", "4.3")
+  solidus_branch = ENV.fetch("SOLIDUS_BRANCH", "v4.4")
   solidus_install_options = "--payment-method=none --frontend=none --authentication=none"
-  if solidus_version >= "4.3"
+  if ["v4.3", "v4.4", "main"].include?(solidus_branch)
     solidus_install_options += " --admin-preview=false"
   end
   Dir.chdir("spec/dummy") do


### PR DESCRIPTION
Rather than using released versions, use the version branches of the Alchemy and Solidus projects. Also adds Ruby 3.4, Alchemy 7.4, and the main branches of both Alchemy and Solidus to the test matrix (let's see what breaks).