### PR TITLE
Lock concurrent-ruby to 1.3.4 on Rails < 7.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,10 @@ gem "listen"
 gem "puma"
 gem "deface"
 
+if ["v4.1", "v4.2"].include?(solidus_branch)
+  gem "concurrent-ruby", "< 1.3.5"
+end
+
 group :development, :test do
   # execjs 2.8 removes deprecation warnings but also breaks a number of dependent projects.
   # in our case the culprit is `handlebars-assets`. The changes between 2.7.0 and 2.8.0 are


### PR DESCRIPTION
The concurrent-ruby folks have released a version without ActiveSupport as a dependency, and now things crash on older Rails versions.

See https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror