### PR TITLE
Fix module icon for Alchemy 7.4

### DIFF
--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -5,7 +5,7 @@ alchemy_module = {
     controller: '/spree/admin/orders',
     action: 'index',
     name: 'Store',
-    icon: 'shopping-cart-line',
+    icon: Alchemy.gem_version >= Gem::Version.new("7.4.0.a") ? 'shopping-cart' : 'shopping-cart-line',
     data: { turbolinks: false },
     sub_navigation: [
       {


### PR DESCRIPTION
Alchemy 7.4 splitted the icon name from the style. line is the default style, so we can just omit it
for all Alchemy version larger than equal to 7.4.0.a