### PR TITLE
Use Alchemy::RelatableResource

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,7 @@ jobs:
           - "3.4"
           - "4.0"
         alchemy:
-          - "8.1-stable"
-          - "8.2-stable"
+          - "8.3-stable"
           - "main"
         solidus:
           - "v4.5"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "solidus_core", github: "solidusio/solidus", branch: solidus_branch
 gem "solidus_backend", github: "solidusio/solidus", branch: solidus_branch
 gem "solidus_frontend", github: "solidusio/solidus_frontend", branch: "main"
 
-alchemy_branch = ENV.fetch("ALCHEMY_BRANCH", "8.2-stable")
+alchemy_branch = ENV.fetch("ALCHEMY_BRANCH", "8.3-stable")
 gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: alchemy_branch
 gem "alchemy-devise", github: "AlchemyCMS/alchemy-devise", branch: alchemy_branch
 

--- a/alchemy-solidus.gemspec
+++ b/alchemy-solidus.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version = Alchemy::Solidus::VERSION
 
-  gem.add_dependency("alchemy_cms", [">= 8.1.0.a", "< 9"])
+  gem.add_dependency("alchemy_cms", [">= 8.3.0", "< 9"])
   gem.add_dependency("solidus_api", [">= 4.0.0", "< 5"])
   gem.add_dependency("solidus_core", [">= 4.0.0", "< 5"])
   gem.add_dependency("solidus_backend", [">= 4.0.0", "< 5"])

--- a/app/jobs/alchemy/solidus/invalidate_elements_cache_job.rb
+++ b/app/jobs/alchemy/solidus/invalidate_elements_cache_job.rb
@@ -4,6 +4,11 @@ module Alchemy
       queue_as :default
 
       def perform(model_name, id)
+        Alchemy::Deprecation.warn <<~WARN
+          Alchemy::Solidus::InvalidateElementsCacheJob is deprecated and will be removed in 9.0.
+          Please use Alchemy::InvalidateElementsCacheJob instead.
+        WARN
+
         now = Time.current
 
         element_ids = model(model_name)

--- a/app/patches/models/alchemy/solidus/spree_product_patch.rb
+++ b/app/patches/models/alchemy/solidus/spree_product_patch.rb
@@ -4,8 +4,6 @@ module Alchemy
   module Solidus
     module SpreeProductPatch
       def self.prepended(base)
-        # Solidus runs touch callbacks on product after_save
-        base.after_touch :touch_alchemy_ingredients
         base.has_many :alchemy_ingredients, class_name: "Alchemy::Ingredients::SpreeProduct", as: :related_object, dependent: :nullify
       end
 
@@ -24,13 +22,9 @@ module Alchemy
         taxons.each(&:touch)
       end
 
-      # Touch all elements that have this product assigned to one of its ingredients.
-      # This cascades to all parent elements and pages as well.
-      def touch_alchemy_ingredients
-        InvalidateElementsCacheJob.perform_later("SpreeProduct", id)
-      end
-
       ::Spree::Product.prepend self
     end
   end
+
+  ::Spree::Product.include RelatableResource
 end

--- a/app/patches/models/alchemy/solidus/spree_taxon_patch.rb
+++ b/app/patches/models/alchemy/solidus/spree_taxon_patch.rb
@@ -4,20 +4,11 @@ module Alchemy
   module Solidus
     module SpreeTaxonPatch
       def self.prepended(base)
-        base.after_update :touch_alchemy_ingredients
-        base.after_touch :touch_alchemy_ingredients
         base.has_many :alchemy_ingredients, class_name: "Alchemy::Ingredients::SpreeTaxon", as: :related_object, dependent: :nullify
       end
 
       ::Spree::Taxon.prepend self
-
-      private
-
-      # Touch all elements that have this taxon assigned to one of its ingredients.
-      # This cascades to all parent elements and pages as well.
-      def touch_alchemy_ingredients
-        InvalidateElementsCacheJob.perform_later("SpreeTaxon", id)
-      end
     end
   end
+  ::Spree::Taxon.include RelatableResource
 end

--- a/app/patches/models/alchemy/solidus/spree_variant_patch.rb
+++ b/app/patches/models/alchemy/solidus/spree_variant_patch.rb
@@ -4,20 +4,12 @@ module Alchemy
   module Solidus
     module SpreeVariantPatch
       def self.prepended(base)
-        base.after_update :touch_alchemy_ingredients
-        base.after_touch :touch_alchemy_ingredients
         base.has_many :alchemy_ingredients, class_name: "Alchemy::Ingredients::SpreeVariant", as: :related_object, dependent: :nullify
       end
 
       ::Spree::Variant.prepend self
-
-      private
-
-      # Touch all elements that have this variant assigned to one of its ingredients.
-      # This cascades to all parent elements and pages as well.
-      def touch_alchemy_ingredients
-        InvalidateElementsCacheJob.perform_later("SpreeVariant", id)
-      end
     end
   end
+
+  ::Spree::Variant.include RelatableResource
 end

--- a/lib/alchemy/solidus/test_support/factories/ingredient_factories.rb
+++ b/lib/alchemy/solidus/test_support/factories/ingredient_factories.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  %w[
+    product
+    taxon
+    variant
+  ].each do |ingredient|
+    factory :"alchemy_ingredient_spree_#{ingredient}", class: "Alchemy::Ingredients::Spree#{ingredient.classify}" do
+      role { ingredient }
+      type { "Alchemy::Ingredients::Spree#{ingredient.classify}" }
+      association :element, name: ingredient, factory: :alchemy_element
+    end
+  end
+end

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -1,45 +1,12 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "alchemy/test_support/relatable_resource_examples"
 
 RSpec.describe Spree::Product, type: :model do
   it { is_expected.to have_many(:alchemy_ingredients) }
 
-  describe "cache invalidation" do
-    let(:page) { create(:alchemy_page) }
-    let(:page_version) { create(:alchemy_page_version, page: page) }
-    let(:element) { create(:alchemy_element, page_version: page_version) }
-    let(:product) { create(:product) }
-
-    context "if assigned to ingredient spree product" do
-      let!(:ingredient) { Alchemy::Ingredients::SpreeProduct.create!(element: element, role: "product", related_object: product) }
-
-      it "invalidates the cache on update" do
-        expect {
-          product.update!(name: "New name")
-        }.to enqueue_job(Alchemy::Solidus::InvalidateElementsCacheJob).with("SpreeProduct", product.id)
-      end
-
-      it "invalidates the cache on touch" do
-        expect {
-          product.touch
-        }.to enqueue_job(Alchemy::Solidus::InvalidateElementsCacheJob).with("SpreeProduct", product.id)
-      end
-    end
-
-    context "if assigned to taxon that is assigned to ingredient spree taxon" do
-      let(:taxon) { create(:taxon) }
-      let!(:product) { create(:product, taxons: [taxon]) }
-
-      let!(:ingredient) { Alchemy::Ingredients::SpreeTaxon.create!(element: element, role: "taxon", related_object: taxon) }
-
-      it "touches ingredient spree taxons elements" do
-        expect {
-          product.touch
-        }.to enqueue_job(Alchemy::Solidus::InvalidateElementsCacheJob).with("SpreeTaxon", taxon.id).and(
-          enqueue_job(Alchemy::Solidus::InvalidateElementsCacheJob).with("SpreeProduct", product.id)
-        )
-      end
-    end
-  end
+  it_behaves_like "a relatable resource",
+    resource_factory_name: "product",
+    ingredient_factory_name: "alchemy_ingredient_spree_product"
 end

--- a/spec/models/spree/taxon_spec.rb
+++ b/spec/models/spree/taxon_spec.rb
@@ -1,27 +1,12 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "alchemy/test_support/relatable_resource_examples"
 
 RSpec.describe Spree::Taxon, type: :model do
   it { is_expected.to have_many(:alchemy_ingredients) }
 
-  describe "cache invalidation" do
-    let(:page) { create(:alchemy_page) }
-    let(:page_version) { create(:alchemy_page_version, page: page) }
-    let(:element) { create(:alchemy_element, page_version: page_version) }
-    let!(:ingredient) { Alchemy::Ingredients::SpreeTaxon.create!(element: element, role: "taxon", related_object: taxon) }
-    let(:taxon) { create(:taxon) }
-
-    it "invalidates the cache on update" do
-      expect {
-        taxon.update!(name: "New name")
-      }.to enqueue_job(Alchemy::Solidus::InvalidateElementsCacheJob).with("SpreeTaxon", taxon.id)
-    end
-
-    it "invalidates the cache on touch" do
-      expect {
-        taxon.touch
-      }.to enqueue_job(Alchemy::Solidus::InvalidateElementsCacheJob).with("SpreeTaxon", taxon.id)
-    end
-  end
+  it_behaves_like "a relatable resource",
+    resource_factory_name: "taxon",
+    ingredient_factory_name: "alchemy_ingredient_spree_taxon"
 end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -1,31 +1,13 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "alchemy/test_support/relatable_resource_examples"
 
 RSpec.describe Spree::Variant, type: :model do
   it { is_expected.to have_many(:alchemy_ingredients) }
 
-  describe "cache invalidation" do
-    let(:page) { create(:alchemy_page) }
-    let(:page_version) { create(:alchemy_page_version, page: page) }
-    let(:element) { create(:alchemy_element, page_version: page_version) }
-    let!(:ingredient) { Alchemy::Ingredients::SpreeVariant.create!(element: element, role: "variant", related_object: variant) }
-    let(:variant) { create(:variant) }
-
-    it "invalidates the cache on update" do
-      expect {
-        variant.update!(sku: "New sku")
-      }.to enqueue_job(Alchemy::Solidus::InvalidateElementsCacheJob).with("SpreeVariant", variant.id).and(
-        enqueue_job(Alchemy::Solidus::InvalidateElementsCacheJob).with("SpreeProduct", variant.product.id)
-      )
-    end
-
-    it "invalidates the cache on touch" do
-      expect {
-        variant.touch
-      }.to enqueue_job(Alchemy::Solidus::InvalidateElementsCacheJob).with("SpreeVariant", variant.id).and(
-        enqueue_job(Alchemy::Solidus::InvalidateElementsCacheJob).with("SpreeProduct", variant.product.id)
-      )
-    end
-  end
+  it_behaves_like "a relatable resource",
+    resource_factory_name: "variant",
+    ingredient_factory_name: "alchemy_ingredient_spree_variant",
+    update_attribute: :sku
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -49,6 +49,7 @@ require "alchemy/test_support/capybara_helpers"
 require "alchemy/test_support/integration_helpers"
 
 FactoryBot.definition_file_paths.append(Alchemy::TestSupport.factories_path)
+FactoryBot.definition_file_paths.append(Alchemy::Solidus::Engine.root.join("lib", "alchemy", "solidus", "test_support", "factories"))
 FactoryBot.reload
 
 require "alchemy/devise/test_support/factories"


### PR DESCRIPTION
Alchemy has a relatable resource module that we
include in Spree:Product, Spree::Taxon and Spree::Variant.
Since RelatableResource [now also has cache invalidation](https://github.com/AlchemyCMS/alchemy_cms/pull/3951)
built in, we can use that.